### PR TITLE
Enable WordPress 4.9.6 GDPR tools

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -74,3 +74,6 @@ add_action( 'wp_ajax_pressbooks_aldine_update_catalog', '\Aldine\Admin\update_ca
 add_filter( 'wpmu_blogs_columns', '\Aldine\Admin\catalog_columns' );
 add_action( 'manage_blogs_custom_column', '\Aldine\Admin\catalog_column', 1, 3 );
 add_action( 'manage_sites_custom_column', '\Aldine\Admin\catalog_column', 1, 3 );
+
+// Remove first submenu page from Tools.
+add_action( 'admin_menu', '\Aldine\Actions\remove_tools_menu' );

--- a/inc/actions/namespace.php
+++ b/inc/actions/namespace.php
@@ -292,3 +292,12 @@ function tinymce_l18n() {
 	</script>
 <?php
 }
+
+/**
+ * Remove top-level tools menu.
+ *
+ * @since 1.4.0
+ */
+function remove_tools_menu() {
+	remove_submenu_page( 'tools.php', 'tools.php' );
+}

--- a/inc/intervention.php
+++ b/inc/intervention.php
@@ -13,7 +13,8 @@ intervention( 'remove-howdy', __( 'Hello,', 'pressbooks-aldine' ) );
 intervention( 'remove-dashboard-items', [ 'activity', 'quick-draft' ] );
 intervention( 'remove-menu-items', [
 	'posts',
-	'tools',
+	'tool-import',
+	'tool-export',
 	'setting-writing',
 	'setting-reading',
 	'setting-permalink',


### PR DESCRIPTION
This PR lets Aldine (and by extension the Pressbooks landing page site) display the export and erase personal data panels introduced in WordPress 4.9.6. They will only be visible to those who have admin access to the root site (network managers).