### PR TITLE
Ensure that unsupported catalog subjects aren't loaded

### DIFF
--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -8,6 +8,7 @@
 namespace Aldine\Helpers;
 
 use function \Pressbooks\Metadata\book_information_to_schema;
+use function \Pressbooks\Metadata\is_bisac;
 use Pressbooks\Book;
 
 /**
@@ -148,7 +149,7 @@ function get_available_licenses( $catalog_data ) {
 function get_available_subjects( $catalog_data ) {
 	$subjects = [];
 	foreach ( $catalog_data['books'] as $book ) {
-		if ( ! empty( $book['subject'] ) ) {
+		if ( ! empty( $book['subject'] ) && ! is_bisac( $book['subject'] ) ) {
 			$subjects[ substr( $book['subject'], 0, 1 ) ][] = substr( $book['subject'], 0, 2 );
 		}
 	}

--- a/partials/book.php
+++ b/partials/book.php
@@ -1,7 +1,10 @@
-<?php use function \Aldine\Helpers\maybe_truncate_string; ?>
+<?php
+use function \Aldine\Helpers\maybe_truncate_string;
+use function \Pressbooks\Metadata\is_bisac;
+?>
 
 <?php
-$subject = ( isset( $book['subject'] ) ) ? substr( $book['subject'], 0, 2 ) : '';
+$subject = ( isset( $book['subject'] ) && ! is_bisac( $book['subject'] ) ) ? substr( $book['subject'], 0, 2 ) : '';
 $date = ( isset( $book['metadata']['datePublished'] ) ) ? str_replace( '-', '', $book['metadata']['datePublished'] ) : '';
 ?>
 <li class="book"


### PR DESCRIPTION
We can't display BISAC subjects in a human-readable format, so we should apply the `is_bisac()` utility to ensure that we only attempt to display Thema subjects on the catalog and book cards within the catalog.