### PR TITLE
Update config - added support for Croatian

### DIFF
--- a/.tx/config
+++ b/.tx/config
@@ -7,5 +7,5 @@ minimum_perc = 0
 source_file = languages/pressbooks-aldine.pot
 source_lang = en
 type = PO
-lang_map = de:de_DE, es:es_ES, fr:fr_FR, gl:gl_ES, nb:nb_NO, it:it_IT, ka:ka_GE, ru:ru_RU, ta:ta_LK
+lang_map = de:de_DE, es:es_ES, fr:fr_FR, gl:gl_ES, nb:nb_NO, it:it_IT, ka:ka_GE, ru:ru_RU, ta:ta_LK, hr:hr_HR
 


### PR DESCRIPTION
Added the support for the Croatian Language hr:hr_HR.

Should be working fine as the Pressbooks plug-in, the McLuhan Theme and the Aldine Theme are 100% translated.