### PR TITLE
Add fallback for CTA shortcode using old attribute (fix #184)

### DIFF
--- a/inc/shortcodes/namespace.php
+++ b/inc/shortcodes/namespace.php
@@ -52,7 +52,7 @@ function call_to_action( $atts ) {
 	);
 
 	// Fallback for shortcodes using the old url attribute
-	if ($atts['link'] === '#' && $atts['url']) {
+	if ( $atts['link'] === '#' && $atts['url'] ) {
 		$atts['link'] = $atts['url'];
 	}
 

--- a/inc/shortcodes/namespace.php
+++ b/inc/shortcodes/namespace.php
@@ -44,11 +44,17 @@ function call_to_action( $atts ) {
 	$atts = shortcode_atts(
 		[
 			'link' => '#',
+			'url' => false,
 			'text' => 'Call To Action',
 		],
 		$atts,
 		'aldine_call_to_action'
 	);
+
+	// Fallback for shortcodes using the old url attribute
+	if ($atts['link'] === '#' && $atts['url']) {
+		$atts['link'] = $atts['url'];
+	}
 
 	return sprintf(
 		'<a class="call-to-action" href="%1$s" title="%2$s">%2$s</a>',


### PR DESCRIPTION
Checks for a non-falsey `url` attribute if the `link` is not set. Resolves #184.