### PR TITLE
Contact Link, Another Alternative

### DIFF
--- a/footer.php
+++ b/footer.php
@@ -23,9 +23,15 @@ if ( $pb_network_contact_form ) {
 	if ( ! empty( $pb_network_contact_link ) ) {
 		$contact_link = $pb_network_contact_link;
 	} else {
-		$contact_link = 'mailto:' . get_option( 'admin_email' );
+		$contact_link = '';
 	}
 }
+/**
+ * Filter the "Contact" link.
+ *
+ * @since Pressbooks 5.6.0
+ */
+$contact_link = apply_filters( 'pb_contact_link', $contact_link );
 
 ?>
 
@@ -87,8 +93,10 @@ if ( $pb_network_contact_form ) {
 				<?php /* translators: %s Pressbooks */ ?>
 				<p class="footer__pressbooks__links__title"><a href="https://pressbooks.com"><?php printf( __( 'Powered by %s', 'pressbooks-aldine' ), '<span class="pressbooks">Pressbooks</span>' ); ?></a></p>
 				<ul class="footer__pressbooks__links__list">
-					<li><a href="https://pressbooks.education/help-and-support/"><?php _e( 'Guides and Tutorials', 'pressbooks-aldine' ); ?></a> |</li>
-					<li><a href="<?php echo $contact_link; ?>"><?php _e( 'Contact', 'pressbooks-aldine' ); ?></a> </li>
+					<li><a href="https://pressbooks.education/help-and-support/"><?php _e( 'Guides and Tutorials', 'pressbooks-aldine' ); ?></a></li>
+					<?php if ( $contact_link ) : ?>
+						<li>|<a href="<?php echo $contact_link; ?>"><?php _e( 'Contact', 'pressbooks-aldine' ); ?></a></li>
+					<?php endif; ?>
 				</ul>
 			</div>
 			<div class="footer__pressbooks__social">


### PR DESCRIPTION
Remove the Contact footer link altogether when neither the form nor a link has been added

Fixes: https://github.com/pressbooks/ideas/issues/180