### PR TITLE
Add network directory exclude when in catalog is toggled

### DIFF
--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -5,10 +5,10 @@
 
 namespace Aldine\Admin;
 
-use PressbooksMix\Assets;
-use Pressbooks\DataCollector\Book as BookDataCollector;
-use Pressbooks\BookDirectory;
 use Pressbooks\Admin\Network\SharingAndPrivacyOptions;
+use PressbooksMix\Assets;
+use Pressbooks\BookDirectory;
+use Pressbooks\DataCollector\Book as BookDataCollector;
 
 /**
  * Uses old option to provide a simpler upgrade path from pressbooks-publisher theme

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -5,8 +5,8 @@
 
 namespace Aldine\Admin;
 
-use Pressbooks\Admin\Network\SharingAndPrivacyOptions;
 use PressbooksMix\Assets;
+use Pressbooks\Admin\Network\SharingAndPrivacyOptions;
 use Pressbooks\BookDirectory;
 use Pressbooks\DataCollector\Book as BookDataCollector;
 

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -7,8 +7,8 @@ namespace Aldine\Admin;
 
 use PressbooksMix\Assets;
 use Pressbooks\DataCollector\Book as BookDataCollector;
-use Pressbooks\Admin\Network\SharingAndPrivacyOptions;
 use Pressbooks\BookDirectory;
+use Pressbooks\Admin\Network\SharingAndPrivacyOptions;
 
 /**
  * Uses old option to provide a simpler upgrade path from pressbooks-publisher theme

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -55,7 +55,7 @@ function update_catalog() {
 		delete_blog_option( $blog_id, \Aldine\Admin\BLOG_OPTION );
 		update_site_meta( $blog_id, BookDataCollector::IN_CATALOG, 0 );
 		// Exclude book when network option book directory non-catalog exclude is enabled
-		$option = get_site_option( pressbooks_sharingandprivacy_options, [], true );
+		$option = get_site_option( 'pressbooks_sharingandprivacy_options', [], true );
 		if (
 			isset( $option[ SharingAndPrivacyOptions::NETWORK_DIRECTORY_EXCLUDED ] ) &&
 			( (bool) $option[ SharingAndPrivacyOptions::NETWORK_DIRECTORY_EXCLUDED ] === true )

--- a/inc/admin/namespace.php
+++ b/inc/admin/namespace.php
@@ -7,6 +7,8 @@ namespace Aldine\Admin;
 
 use PressbooksMix\Assets;
 use Pressbooks\DataCollector\Book as BookDataCollector;
+use Pressbooks\Admin\Network\SharingAndPrivacyOptions;
+use Pressbooks\BookDirectory;
 
 /**
  * Uses old option to provide a simpler upgrade path from pressbooks-publisher theme
@@ -52,7 +54,16 @@ function update_catalog() {
 	} else {
 		delete_blog_option( $blog_id, \Aldine\Admin\BLOG_OPTION );
 		update_site_meta( $blog_id, BookDataCollector::IN_CATALOG, 0 );
+		// Exclude book when network option book directory non-catalog exclude is enabled
+		$option = get_site_option( pressbooks_sharingandprivacy_options, [], true );
+		if (
+			isset( $option[ SharingAndPrivacyOptions::NETWORK_DIRECTORY_EXCLUDED ] ) &&
+			( (bool) $option[ SharingAndPrivacyOptions::NETWORK_DIRECTORY_EXCLUDED ] === true )
+		) {
+			BookDirectory::init()->deleteBookFromDirectory( [ $blog_id ] );
+		}
 	}
+	update_blog_details( $blog_id, [ 'last_updated' => current_time( 'mysql', true ) ] );
 }
 
 /**


### PR DESCRIPTION
Issue: pressbooks/pressbooks#2032

Fix and test:

In the dashboard's 'All Books', if the network directory exclude flag is on, changing the book's in catalog flag will update the book's last updated attribute. if the network directory exclude flag is on and a book is 'in catalog', changing the book from 'in catalog' to not 'in catalog' will trigger a book directory delete action for that single book.

Test:
Updated time can be verified in the book list last edited and also in the book api. The book deletion process can be verified locally or once the book fetcher is deployed.