### PR TITLE
ci: add automatic POT updates to dev branch

### DIFF
--- a/.github/workflows/update-pot.yml
+++ b/.github/workflows/update-pot.yml
@@ -1,0 +1,38 @@
+name: Update POT file
+
+on:
+  push:
+    branches:
+    - dev
+    paths:
+    - '**.php'
+    - '**.js'
+
+jobs:
+  update-pot:
+    runs-on: ubuntu-latest
+    if: github.repository == "pressbooks/pressbooks-aldine" # Don't run on forks.
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup PHP with tools
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.3'
+        tools: composer, wp-cli
+    - name: Install dependencies
+      run: |
+        wp package install wp-cli/i18n-command:2.2.6
+        wp package install pressbooks/pb-cli:dev-dev#800cec8
+        composer require jenssegers/blade:1.1.0
+    - name: Update POT file
+      run: wp pb make-pot . languages/pressbooks-aldine.pot --require=vendor/autoload.php --domain=pressbooks-aldine --slug=pressbooks-aldine --package-name="Aldine" --headers="{\"Report-Msgid-Bugs-To\":\"https://github.com/pressbooks/pressbooks-aldine/issues\"}"
+    # Remove the next four lines and uncomment the last five lines once the process has been confirmed to work as desired.
+    - uses: actions/upload-artifact@v2
+      with:
+        name: pressbooks-aldine.pot
+        path: languages/pressbooks-aldine.pot
+    # - name: Commit updated POT file
+    #   uses: stefanzweifel/git-auto-commit-action@v4.1.1
+    #   with:
+    #     commit_message: 'chore(l10n): update languages/pressbooks-aldine.pot'
+    #     file_pattern: '*.pot'


### PR DESCRIPTION
This PR uses the [shivammathur/setup-php](https://github.com/shivammathur/setup-php) action to install WP-CLI, the WP-CLI i18n command, and Pressbooks CLI. It then runs the `wp pb make-pot` command to generate an updated `.pot` file for the plugin.

## Notes

This action will only run:

- On the base repository (not on forks)
- On the dev branch
- When either `.js` or `.php` files have been modified (these are the only sources for localizable strings so the action can be skipped if neither file type has been modified)

Currently, this action _does not_ automatically commit the updated `.pot` file. Instead, it attaches it as a workflow artifact (see here for an example: https://github.com/greatislander/pressbooks-lti-provider/actions/runs/757127517). These artifacts can be compared to the existing `.pot` file over the coming weeks, and once the dev team is satisfied with the consistency and accuracy of the results, [these instructions](https://github.com/greatislander/pressbooks-aldine/blob/c20b801c48fa0d37aa688dd4d1f82b7cdf2c6ac2/.github/workflows/update-pot.yml#L29) can be followed to enable auto-commit and remove the workflow artifact upload step.