### PR TITLE
Use classic widgets in WP 5.8

### DIFF
--- a/inc/actions/namespace.php
+++ b/inc/actions/namespace.php
@@ -95,6 +95,13 @@ function setup() {
 
 	// Add shortcode buttons.
 	add_action( 'init', __NAMESPACE__ . '\register_shortcode_buttons' );
+
+	remove_theme_support( 'widgets-block-editor' );
+
+	// Disables the block editor from managing widgets in the Gutenberg plugin.
+	add_filter( 'gutenberg_use_widgets_block_editor', '__return_false' );
+	// Disables the block editor from managing widgets.
+	add_filter( 'use_widgets_block_editor', '__return_false' );
 }
 
 /**


### PR DESCRIPTION
This PR is part of https://github.com/pressbooks/pressbooks/issues/2232

This removes the new widgets blocks from WP 5.8 https://make.wordpress.org/core/2021/06/29/block-based-widgets-editor-in-wordpress-5-8/ and reverts them to use the classic ones.

## How to test

1. Upgrade your wp installation in your local env
2. See the new gutenberg block based widgets added in the widgets configuration
3. Change the aldine branch to this one
4. See the classic pressbooks widgets with no changes