### PR TITLE
Improve CI flow, add experimental test for PHP 7.4

### DIFF
--- a/.github/workflows/.pipeline.yml
+++ b/.github/workflows/.pipeline.yml
@@ -9,12 +9,19 @@ on:
 jobs:
   tests:
     runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.experimental }}
     strategy:
+      fail-fast: false
       matrix:
         php: [ 7.3 ]
         os: [ ubuntu-18.04 ]
         wordpress: [ 5.8, latest ]
-
+        experimental: [false]
+        include:
+          - php: 7.4
+            os: ubuntu-20.04
+            wordpress: latest
+            experimental: true
     name: Test - PHP ${{ matrix.php }} - WP ${{ matrix.wordpress }}
 
     env:
@@ -42,6 +49,12 @@ jobs:
           path: vendor
           key: php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
 
+      - name: Cache node modules
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.OS }}-build-${{ hashFiles('**/package-lock.json') }}
+
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
@@ -49,15 +62,23 @@ jobs:
           tools: phpcs, composer:v1
           coverage: pcov
 
-      - name: Install dependencies
+      - name: Install Node dependencies
         run: |
           node -v
           npm install
+        if: matrix.experimental == false
+
+      - name: Install PHP dependencies
+        run: |
           export PATH="$HOME/.composer/vendor/bin:$PATH"
           composer install --no-interaction
           composer global require "phpunit/phpunit:7.5.20"
 
       - name: Run Lint
+        run: npm run lint
+        if: matrix.experimental == false
+
+      - name: Run PHP CodeSniffer
         run: composer standards
 
       - name: Install WP tests
@@ -68,6 +89,8 @@ jobs:
 
       - name: Run Frontend Tests
         run: npm run test
+        if: matrix.experimental == false
+
       - name: Run PHP Tests
         run: vendor/bin/phpunit
 
@@ -91,6 +114,7 @@ jobs:
           wp dist-archive $GITHUB_REPO_SLUG $GITHUB_BUILD_PATH/$GITHUB_REPO_SLUG-$GITHUB_TAG.zip
           cd $GITHUB_BUILD_PATH
           ls $GITHUB_BUILD_PATH
+
       - name: Deploy
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
This PR improves the CI flow and adds an experimental test that runs against PHP 7.4, Ubuntu 20,04 and the latest version of WP.

Partial fix for pressbooks/private#602