### PR TITLE
Fix aria-label for catalog nav

### DIFF
--- a/partials/paged-navigation.php
+++ b/partials/paged-navigation.php
@@ -1,5 +1,5 @@
-<nav class="booknav" aria-labelledby="latest-books-title book-navigation">
-	<span class="screen-reader-text"><?php _e( 'Navigation', 'pressbooks-aldine' ); ?></span>
+<nav class="booknav" aria-labelledby="catalog-books">
+	<span class="screen-reader-text" id="catalog-books"><?php _e( 'Book Catalog Navigation', 'pressbooks-aldine' ); ?></span>
 	<?php if ( $previous_page ) : ?>
 		<a class="previous" rel="previous" data-page="<?php echo $previous_page; ?>" href="<?php echo network_home_url( "/page/$previous_page/#latest-books" ); ?>">
 			<span class="screen-reader-text"><?php _e( 'Previous Page', 'pressbooks' ); ?></span>


### PR DESCRIPTION
This PR fixes a broken aria label for the catalog navigation element on the network home page.

To test:
1. Apply this branch and add more than 1 book to the network catalog
2. Check the HTML output with the w3c validator and make sure that the 'The aria-labelledby attribute must point to an element in the same document.' error is no longer present for the catalog nav element