### PR TITLE
fix: update content for default about and help pages

### DIFF
--- a/inc/activation/namespace.php
+++ b/inc/activation/namespace.php
@@ -36,16 +36,13 @@ function create_default_content() {
 				'post_content' => apply_filters(
 					'pb_root_about_page_content',
 					sprintf(
-						'<p>%1$s</p><ul><li>%2$s</li><li>%3$s</li><li>%4$s</li></ul><p>%5$s</p><p>%6$s</p>',
-						__( 'Pressbooks is simple book production software. You can use Pressbooks to publish textbooks, scholarly monographs, syllabi, fiction and non-fiction books, white papers, and more in multiple formats including:', 'pressbooks-aldine' ),
-						__( 'MOBI (for Kindle ebooks)', 'pressbooks-aldine' ),
-						__( 'EPUB (for all other ebookstores)', 'pressbooks-aldine' ),
-						__( 'designed PDF (for print-on-demand and digital distribution)', 'pressbooks-aldine' ),
-						__( 'Pressbooks is used by educational institutions around the world as well as authors and publishers.', 'pressbooks' ),
+						'<p>%1$s</p><p>%2$s</p>',
+						__( 'Pressbooks is simple book production software that makes it easy to write, develop, and share your ideas. You can use Pressbooks to publish open educational resources, textbooks, scholarly monographs, fiction and non-fiction books, white papers, syllabi, and more. Pressbooks lets creators quickly publish their content to the web and produce exports in multiple formats, including accessible EPUBs and PDFs specially designed for print-on-demand or digital distribution.', 'pressbooks-aldine' ),
 						sprintf(
-							/* translators: %s link to about page */
-							__( 'For more information about Pressbooks, %s.', 'pressbooks-aldine' ),
-							sprintf( '<a href="https://pressbooks.com/about">%s</a>', __( 'see here', 'pressbooks-aldine' ) )
+							/* translators: %1$s: link to Pressbooks product page; %2$2: link to Pressbooks getting started page */
+							__( 'Pressbooks\' %1$s are used by hundreds of educational institutions and thousands of individual authors and publishers around the world. %2$s to learn more about how you or your institution can get started with Pressbooks.', 'pressbooks' ),
+							sprintf( '<a href="https://pressbooks.com/our-products/">%s</a>', __( 'suite of products', 'pressbooks-aldine' ) ),
+							sprintf( '<a href="https://pressbooks.com/get-started/">%s</a>', __( 'Contact us', 'pressbooks-aldine' ) )
 						)
 					)
 				),
@@ -55,14 +52,34 @@ function create_default_content() {
 				'post_content' => apply_filters(
 					'pb_root_help_page_content',
 					sprintf(
-						'<p>%1$s</p><p>%2$s</p>',
+						'<p>%1$s</p><p>%2$s</p><p>%3$s</p><p>%4$s</p><p>%5$s</p>',
 						sprintf(
-							/* translators: %1$s: link to how to page; %2$s: link to guide */
-							__( 'The easiest way to get started with Pressbooks is to follow our %1$s. Or, you can review our %2$s.', 'pressbooks-aldine' ),
-							sprintf( '<a href="https://pressbooks.com/how-to-make-a-book-with-pressbooks">%s</a>', __( '4 Step Guide to Making a Book on Pressbooks', 'pressbooks-aldine' ) ),
-							sprintf( '<a href="https://guide.pressbooks.com/">%s</a>', __( 'Guide to Using Pressbooks', 'pressbooks-aldine' ) )
+						/* translators: %s: link to guide */
+							__( 'Are you looking for help on your Pressbooks project? The most comprehensive resource available is the %s, which contains everything you need to know about creating, enriching and exporting your work.', 'pressbooks-aldine' ),
+							sprintf( '<a href="https://guide.pressbooks.com/">%s</a>', __( 'Pressbooks User Guide', 'pressbooks-aldine' ) )
 						),
-						__( 'If you require further assistance, please contact your network manager.', 'pressbooks-aldine' )
+						sprintf(
+						/* translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist */
+							__( 'You can find short video tutorials and webinars about features and product updates on the %1$s. If you’re just getting started with Pressbooks, this %2$s will guide you.', 'pressbooks-aldine' ),
+							sprintf( '<a href="https://www.youtube.com/c/Pressbooks">%s</a>', __( 'Pressbooks YouTube channel', 'pressbooks-aldine' ) ),
+							sprintf( '<a href="https://www.youtube.com/playlist?list=PLMFmJu3NJheuRt1rZwNCEElROtSjc5dJG">%s</a>', __( 'short video series', 'pressbooks-aldine' ) )
+						),
+						sprintf(
+						/* translators: %s: link to Pressbooks webinar schedule */
+							__( 'If you learn best by learning by attending live training sessions, you can register for and attend one of Pressbooks\' %s.', 'pressbooks-aldine' ),
+							sprintf( '<a href="https://pressbooks.com/webinars/">%s</a>', __( 'monthly webinars', 'pressbooks-aldine' ) )
+						),
+						sprintf(
+						/* translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum */
+							__( 'The %1$s also contains links to other useful support resources and has answers to some commonly asked questions. Pressbooks also maintains a %2$s where you can ask and answer questions of other users.', 'pressbooks-aldine' ),
+							sprintf( '<a href="https://pressbooks.com/support/">%s</a>', __( 'Pressbooks support page', 'pressbooks-aldine' ) ),
+							sprintf( '<a href="https://pressbooks.community/">%s</a>', __( 'community forum', 'pressbooks-aldine' ) )
+						),
+						sprintf(
+						/* translators: %s: link to Pressbooks support request form */
+							__( 'For additional support needs, reach out to your institution’s Pressbooks network managers. If you don’t know who your network managers are, please fill out the %s to be put in touch with them.', 'pressbooks-aldine' ),
+							sprintf( '<a href=""', __( 'support request form', 'pressbooks-aldine' ) )
+						)
 					)
 				),
 			],

--- a/inc/activation/namespace.php
+++ b/inc/activation/namespace.php
@@ -36,8 +36,9 @@ function create_default_content() {
 				'post_content' => apply_filters(
 					'pb_root_about_page_content',
 					sprintf(
-						'<p>%1$s</p><p>%2$s</p>',
-						__( 'Pressbooks is simple book production software that makes it easy to write, develop, and share your ideas. You can use Pressbooks to publish open educational resources, textbooks, scholarly monographs, fiction and non-fiction books, white papers, syllabi, and more. Pressbooks lets creators quickly publish their content to the web and produce exports in multiple formats, including accessible EPUBs and PDFs specially designed for print-on-demand or digital distribution.', 'pressbooks-aldine' ),
+						'<p>%1$s</p><p>%2$s</p><p>%3$s</p>',
+						__( 'Pressbooks is simple book production software that makes it easy to write, develop, and share your ideas. You can use Pressbooks to publish open educational resources, textbooks, scholarly monographs, fiction and non-fiction books, white papers, syllabi, and more.', 'pressbooks-aldine' ),
+						__( 'Pressbooks lets creators quickly publish their content to the web and produce exports in multiple formats, including accessible EPUBs and PDFs specially designed for print-on-demand or digital distribution.', 'pressbooks-aldine' ),
 						sprintf(
 							/* translators: %1$s: link to Pressbooks product page; %2$2: link to Pressbooks getting started page */
 							__( 'Pressbooks\' %1$s are used by hundreds of educational institutions and thousands of individual authors and publishers around the world. %2$s to learn more about how you or your institution can get started with Pressbooks.', 'pressbooks' ),
@@ -78,7 +79,7 @@ function create_default_content() {
 						sprintf(
 						/* translators: %s: link to Pressbooks support request form */
 							__( 'For additional support needs, reach out to your institution’s Pressbooks network managers. If you don’t know who your network managers are, please fill out the %s to be put in touch with them.', 'pressbooks-aldine' ),
-							sprintf( '<a href=""', __( 'support request form', 'pressbooks-aldine' ) )
+							sprintf( '<a href="https://pressbooks.com/pressbooksedu-support/">%s</a>', __( 'support request form', 'pressbooks-aldine' ) )
 						)
 					)
 				),


### PR DESCRIPTION
This PR updates the content on the default 'about' and 'help' pages. It solves https://github.com/pressbooks/pressbooks-aldine/issues/298

To test:
1. Delete the about and help pages on the test network.
2. Change the network theme to a non-Aldine theme (publisher if it is installed)
3. Visit the network's settings page (wp-admin/network/site-settings.php?id=1) and change the pb_aldine_activated 'option' to `0` and save
4. Change the network theme back to Aldine
5. Test that the new pages have been created and look as expected
6. Visit the network's settings page (wp-admin/network/site-settings.php?id=1) and change the pb_aldine_activated 'option' back to `1`