### PR TITLE
feat: Support new institution structure

### DIFF
--- a/partials/book.php
+++ b/partials/book.php
@@ -10,9 +10,12 @@ use function \Pressbooks\Metadata\is_bisac;
 
 $subject = ( isset( $book['subject'] ) && ! is_bisac( $book['subject'] ) ) ? substr( $book['subject'], 0, 2 ) : '';
 $date = ( isset( $book['metadata']['datePublished'] ) ) ? str_replace( '-', '', $book['metadata']['datePublished'] ) : '';
-$institutions = array_reduce( $book['metadata']['institutions'] ?? [], static function ( $carry, $item ) {
-	return array_merge( $carry, [ $item['name'] ] );
-}, [] );
+$institution_codes = array_map( static function ( $item ) {
+	return $item['code'];
+}, $book['metadata']['institutions'] ?? [] );
+$institution_names = array_map( static function ( $item ) {
+	return \Pressbooks\Metadata\get_institution_by_code( $item['code'] );
+}, $book['metadata']['institutions'] ?? [] );
 ?>
 <li class="book"
 <?php
@@ -20,7 +23,7 @@ if ( $date ) {
 	?>
 	data-date-published="<?php echo $date; ?>"<?php } ?>
 	data-license="<?php echo ( new \Pressbooks\Licensing() )->getLicenseFromUrl( $book['metadata']['license']['url'] ); ?>"
-	data-institution="<?php echo implode( ',', $institutions ); ?>"
+	data-institution="<?php echo implode( ',', $institution_codes ); ?>"
 	<?php
 	if ( ! empty( $subject ) ) {
 		?>
@@ -45,9 +48,9 @@ if ( $date ) {
 		<a href="<?php echo network_home_url( "/catalog/#$subject" ) ?>"><?php echo \Pressbooks\Metadata\get_subject_from_thema( $book['subject'] ); ?></a>
 	</p>
 	<?php } ?>
-	<?php if ( $institutions ) : ?>
+	<?php if ( $institution_names ) : ?>
 	<p class="book__institutions">
-		<?php echo implode( ', ', $institutions ); ?>
+		<?php echo implode( ', ', $institution_names ); ?>
 	</p>
 	<?php endif; ?>
 	<p class="book__read-more">

--- a/partials/content-page-catalog.php
+++ b/partials/content-page-catalog.php
@@ -41,7 +41,7 @@
 			<label for="all-institutions"><?php _e( 'All Institutions', 'pressbooks-aldine' ); ?> <svg class="checked"><use xlink:href="#checkmark" /></svg></label>
 			<?php
 			foreach ( $institutions as $key => $value ) :
-				if ( in_array( $key, $available_institutions, true ) ) :
+				if ( array_key_exists( $key, $available_institutions ) ) :
 					?>
 					<input type="radio" name="institution" id="<?php echo $key; ?>" value="<?php echo $key; ?>" <?php checked( $institution, $key ); ?>>
 					<label for="<?php echo $key; ?>"><?php echo $value; ?> <svg class="checked"><use xlink:href="#checkmark" /></svg></label>


### PR DESCRIPTION
Partial fix for pressbooks/pressbooks#2595

This PR adds support to the structural changes in the institutions field (see pressbooks/pressbooks#2602).

#### How to test

1. Add some books to the catalog page.
1. Add one or more institutions to books in the Book Info page.
1. Go to the catalog page and check if the institutions are properly displayed.
1. Apply filters, combining subject, license and institutions and make sure books are correctly filtered.
