### PR TITLE
feat: use featured image when provided

### DIFF
--- a/header.php
+++ b/header.php
@@ -45,14 +45,19 @@
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'pressbooks-aldine' ); ?></a>
 	<header class="header" role="banner" style="background-image: url(
 	<?php
-	if ( is_front_page() ) {
-		if ( has_header_image() ) {
-			echo( get_header_image() );
-		} else {
-			echo get_template_directory_uri() . '/dist/images/header.jpg';
-		}
+
+	if ( has_post_thumbnail() ) {
+		echo get_the_post_thumbnail_url();
 	} else {
-		echo get_template_directory_uri() . '/dist/images/catalog-header.jpg';
+		if (is_front_page()) {
+			if (has_header_image()) {
+				echo(get_header_image());
+			} else {
+				echo get_template_directory_uri() . '/dist/images/header.jpg';
+			}
+		} else {
+			echo get_template_directory_uri() . '/dist/images/catalog-header.jpg';
+		}
 	}
 	?>
 	);">

--- a/header.php
+++ b/header.php
@@ -49,9 +49,9 @@
 	if ( has_post_thumbnail() ) {
 		echo get_the_post_thumbnail_url();
 	} else {
-		if (is_front_page()) {
-			if (has_header_image()) {
-				echo(get_header_image());
+		if ( is_front_page() ) {
+			if ( has_header_image() ) {
+				echo( get_header_image() );
 			} else {
 				echo get_template_directory_uri() . '/dist/images/header.jpg';
 			}


### PR DESCRIPTION
Issue #189, pressbooks/pressbooks-network-catalog#13

This PR changes the behaviour of the page layout to render the post featured image when provided. If no featured image is provided we fallback the the old behaviour.

### How to test

1. Set the featured image for any post and visit the post to see the featured image being rendered
2. Set the customizer header image and make sure the featured image has a higher priority
3. With pressbooks-network-catalog disabled, try to force set a featured image for the catalog page and make sure it's not rendered in the Aldine Catalog
4. With pressbooks-network-catalog enabled you should see the featured image instead of the default background image

>**Note**
To force set a featured image change the Catalog page template to "Default template", update the image and then change the template back to "Catalog"