### PR TITLE
fix: aldine contact form warnings

### DIFF
--- a/partials/contact-form.php
+++ b/partials/contact-form.php
@@ -31,65 +31,67 @@ $honeypot = 'firstname' . wp_rand();
 			</label>
 		</p>
 		<p class="form__row">
-			<input id="contact-name"
-			<?php
-			if ( isset( $contact_form_response['field'] ) && $contact_form_response['field'] === 'visitor_name' ) :
-				?>
-				class="error"<?php endif; ?> type="text" name="visitor_name" value="
-							<?php
-							if ( $contact_form_response['status'] === 'error' ) :
-								echo $contact_form_response['values']['visitor_name'];
-			endif;
-							?>
-			" required>
+			<input
+					id="contact-name"
+					<?php if ( isset( $contact_form_response['field'] ) && $contact_form_response['field'] === 'visitor_name' ) : ?>
+						class="error"
+					<?php endif; ?>
+					type="text"
+					name="visitor_name"
+					<?php if ( $contact_form_response && $contact_form_response['status'] === 'error' ) : ?>
+						value="<?php echo $contact_form_response['values']['visitor_name']; ?>"
+					<?php endif; ?>
+					required
+			/>
 			<label for="contact-name">
 				<?php _e( 'Your name (required)', 'pressbooks-aldine' ); ?>
 			</label>
 		</p>
 		<p class="form__row">
-			<input id="contact-email"
-			<?php
-			if ( isset( $contact_form_response['field'] ) && $contact_form_response['field'] === 'visitor_email' ) :
-				?>
-				class="error" <?php endif; ?>type="email" name="visitor_email" value="
-								<?php
-								if ( $contact_form_response['status'] === 'error' ) :
-										echo $contact_form_response['values']['visitor_email'];
-			endif;
-								?>
-			" required>
+			<input
+					id="contact-email"
+					<?php if ( isset( $contact_form_response['field'] ) && $contact_form_response['field'] === 'visitor_email' ) : ?>
+						class="error"
+					<?php endif; ?>
+					type="email"
+					name="visitor_email"
+					<?php if ( $contact_form_response && $contact_form_response['status'] === 'error' ) : ?>
+						value="<?php echo $contact_form_response['values']['visitor_email']; ?>"
+					<?php endif; ?>
+					required
+			/>
 			<label for="contact-email">
 				<?php _e( 'Your email address (required)', 'pressbooks-aldine' ); ?>
 			</label>
 		</p>
 		<p class="form__row">
-			<input id="contact-institution"
-			<?php
-			if ( isset( $contact_form_response['field'] ) && $contact_form_response['field'] === 'visitor_institution' ) :
-				?>
-				class="error" <?php endif; ?>type="text" name="visitor_institution" value="
-								<?php
-								if ( $contact_form_response['status'] === 'error' ) :
-									echo $contact_form_response['values']['visitor_institution'];
-			endif;
-								?>
-			" required>
+			<input
+					id="contact-institution"
+					<?php if ( isset( $contact_form_response['field'] ) && $contact_form_response['field'] === 'visitor_institution' ) : ?>
+						class="error"
+					<?php endif; ?>
+					type="text"
+					name="visitor_institution"
+					<?php if ( $contact_form_response && $contact_form_response['status'] === 'error' ) : ?>
+						value="<?php echo $contact_form_response['values']['visitor_institution']; ?>"
+					<?php endif; ?>
+					required
+			/>
 			<label for="contact-institution">
 				<?php _e( 'Your institution (required)', 'pressbooks-aldine' ); ?>
 			</label>
 		</p>
 		<p class="form__row">
-			<textarea id="contact-message"
-			<?php
-			if ( isset( $contact_form_response['field'] ) && $contact_form_response['field'] === 'message' ) :
-				?>
-				class="error" <?php endif; ?>name="message" required>
-								<?php
-								if ( $contact_form_response['status'] === 'error' ) :
-									echo $contact_form_response['values']['message'];
-			endif;
-								?>
-			</textarea>
+			<textarea
+					id="contact-message"
+					<?php if ( isset( $contact_form_response['field'] ) && $contact_form_response['field'] === 'message' ) : ?>
+						class="error"
+					<?php endif; ?>
+					name="message"
+					required
+			><?php if ( $contact_form_response && $contact_form_response['status'] === 'error' ) : ?>
+					<?php echo $contact_form_response['values']['message']; ?>
+				<?php endif; ?></textarea>
 			<label for="contact-message">
 				<?php _e( 'Your message (required)', 'pressbooks-aldine' ); ?>
 			</label>


### PR DESCRIPTION
This PR aims to remove the contact form warnings/notices we see in the Aldine page.

Before
<img width="2045" alt="image" src="https://user-images.githubusercontent.com/1761690/192792668-7809c73b-5468-4f2f-930f-c7b59ebdf031.png">

After
<img width="2045" alt="image" src="https://user-images.githubusercontent.com/1761690/192792730-d9487ab5-fd5c-44c0-8016-537373961d59.png">

Form submission and form behaviour should work as before.