### PR TITLE
Change default redirect behaviour from 'sign in' link

### DIFF
--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -354,7 +354,7 @@ function get_default_menu( $items = '' ) {
 	if ( ! is_user_logged_in() ) {
 		$items .= sprintf(
 			'<li class="%3$s %3$s-%4$s"><a href="%1$s">%2$s</a></li>',
-			wp_login_url( get_permalink() ),
+			wp_login_url(),
 			__( 'Sign In', 'pressbooks-aldine' ),
 			$item_classes['prefix'],
 			$item_classes['SignIn']


### PR DESCRIPTION
Partial fix for https://github.com/pressbooks/pressbooks/issues/3017. This PR changes default login behaviour for the sign in link on all Aldine menus so that the user is redirected to the user dashboard/admin menu instead of the page they clicked sign-in from. Signing in from book pages will still result in returning to the page logged in from as a logged in user (expected behaviour for private books, etc.)