### PR TITLE
feat: add link to latest book in the home page

### DIFF
--- a/partials/content-front-page.php
+++ b/partials/content-front-page.php
@@ -62,11 +62,11 @@ if ( $catalog_page ) {
 		</div>
 		<p class="catalog-link">
 			<a class="call-to-action" href="<?php echo $catalog_permalink ?? ''; ?>">
-													<?php
-													_e('View Complete Catalog',
-													'pressbooks-aldine');
-													?>
-						</a>
+				<?php
+				_e('View Complete Catalog',
+				'pressbooks-aldine');
+				?>
+			</a>
 		</p>
 	</div>
 <?php endif; ?>

--- a/partials/featured-book.php
+++ b/partials/featured-book.php
@@ -8,7 +8,10 @@
 use function \Aldine\Helpers\maybe_truncate_string;
 ?>
 <div class="featured_book">
-	<div class="featured_book__cover" style="background-image: url('<?php echo $book['metadata']['image']; ?>' );"></div>
+	<!-- accessible link -->
+	<a href="<?php echo $book['link']; ?>" aria-label="<?php echo esc_attr( $book['metadata']['name'] ); ?>">
+		<div class="featured_book__cover" style="background-image: url('<?php echo $book['metadata']['image']; ?>' );"></div>
+	</a>
 	<p class="featured_book__title">
 		<a href="<?php echo $book['link']; ?>"><?php echo maybe_truncate_string( $book['metadata']['name'] ); ?></a>
 	</p>

--- a/partials/featured-book.php
+++ b/partials/featured-book.php
@@ -10,8 +10,8 @@ use function \Aldine\Helpers\maybe_truncate_string;
 <div class="featured_book">
 	<a href="<?php echo $book['link']; ?>" aria-label="<?php echo esc_attr( $book['metadata']['name'] ); ?>">
 		<div class="featured_book__cover" style="background-image: url('<?php echo $book['metadata']['image']; ?>' );"></div>
+		<p class="featured_book__title">
+			<?php echo maybe_truncate_string( $book['metadata']['name'] ); ?>
+		</p>
 	</a>
-	<p class="featured_book__title">
-		<a href="<?php echo $book['link']; ?>"><?php echo maybe_truncate_string( $book['metadata']['name'] ); ?></a>
-	</p>
 </div>

--- a/partials/featured-book.php
+++ b/partials/featured-book.php
@@ -8,7 +8,6 @@
 use function \Aldine\Helpers\maybe_truncate_string;
 ?>
 <div class="featured_book">
-	<!-- accessible link -->
 	<a href="<?php echo $book['link']; ?>" aria-label="<?php echo esc_attr( $book['metadata']['name'] ); ?>">
 		<div class="featured_book__cover" style="background-image: url('<?php echo $book['metadata']['image']; ?>' );"></div>
 	</a>


### PR DESCRIPTION
Issue: https://github.com/pressbooks/ideas/issues/521

This pull request ensures that the book cover image is wrapped in an accessible link to the book's page.

Accessibility improvement:

* [`partials/featured-book.php`](diffhunk://#diff-b1c4c30677114bc6bf976b48ba123637142a3c0d6f430defe174fcaaed9f0c95R11-R14): Added an `aria-label` to the book cover link to enhance accessibility by providing a descriptive label for screen readers.

### Testing notes
- Go to Network Admin > Appearance> Customize Home Page > Front Page Catalog.
- Enable the "Show Front Page Catalog" checkbox and select some books for the home page and save it.
- Make sure those are on the home page and clicking on the image redirects to each book's home page.