### PR TITLE
fix: sort search results by blog title

### DIFF
--- a/inc/customizer/namespace.php
+++ b/inc/customizer/namespace.php
@@ -35,6 +35,9 @@ function ajax_search_catalog_books(): void {
 				'compare' => '=', //phpcs:ignore HM.Performance.SlowMetaQuery.nonperformant_comparison
 			],
 		],
+		'orderby'    => 'meta_value',
+		'meta_key'   => $dc::TITLE,
+		'order'      => 'ASC',
 		'public'     => 1,
 		'archived'   => 0,
 		'spam'       => 0,

--- a/inc/customizer/namespace.php
+++ b/inc/customizer/namespace.php
@@ -35,7 +35,7 @@ function ajax_search_catalog_books(): void {
 				'compare' => '=', //phpcs:ignore HM.Performance.SlowMetaQuery.nonperformant_comparison
 			],
 		],
-		'orderby'    => 'meta_value',
+		'orderby'    => 'meta_value', // phpcs:ignore HM.Performance.SlowOrderBy.slow_order
 		'meta_key'   => $dc::TITLE,
 		'order'      => 'ASC',
 		'public'     => 1,


### PR DESCRIPTION
This pull request includes a small change to the `ajax_search_catalog_books` function in the `inc/customizer/namespace.php` file. The change adds sorting functionality to the catalog book search by title.