### PR TITLE
fix: add page title as a heading for custom home

### DIFF
--- a/partials/content-front-page.php
+++ b/partials/content-front-page.php
@@ -37,11 +37,17 @@ if ( $catalog_page ) {
 	$catalog_permalink = get_permalink( $catalog_page->ID );
 }
 
+$title_text = null;
+
+if ( get_page_template_slug() === 'page-custom-home.php' ) {
+	$title_text = get_the_title( $post->ID );
+}
+
 ?>
 
 <article id="post-<?php the_ID(); ?>" <?php post_class(); ?>>
 	<header class="entry-header">
-		<h1 class="entry-title"><?php echo get_bloginfo( 'name', 'display' ); ?></h1>
+		<h1 class="entry-title"><?php echo $title_text ?? get_bloginfo( 'name', 'display' ); ?></h1>
 		<p class="entry-description"><?php echo $tagline_text ?? get_bloginfo( 'description', 'display' ); ?></p>
 	</header><!-- .entry-header -->
 


### PR DESCRIPTION
Issue: https://github.com/pressbooks/ideas/issues/526

This pull request introduces a conditional update to the front-page template, allowing the page title to dynamically reflect the title of the current post when a specific custom template is used. The most important change is the addition of logic to set the `$title_text` variable based on the template slug.

Dynamic title logic:

* [`partials/content-front-page.php`](diffhunk://#diff-22cebb3990636ded57f7fe519de0e0486b46ec6db1d86160c3eee8ce4ded945fR40-R50): Added a new `$title_text` variable and logic to set it to the current post's title if the `page-custom-home.php` template is being used. Updated the `<h1>` tag to display `$title_text` if available, falling back to the site's name otherwise.

### Testing sample
Add a new additional home and make sure the title of the page is being displayed as a header instead of the network title.