### PR TITLE
fix: header_links customizer value should be primary color as default

### DIFF
--- a/inc/customizer/namespace.php
+++ b/inc/customizer/namespace.php
@@ -159,7 +159,7 @@ function customize_register( \WP_Customize_Manager $wp_customize ) {
 			'label' => __( 'Accent Foreground Color', 'pressbooks-aldine' ),
 			'description' => __( 'Used for text on an accent color background.', 'pressbooks-aldine' ),
 		],
-	] as $color ) {
+	] as &$color ) {
 		if ( $color['slug'] === 'header_links' ) {
 			$primary = get_option( 'pb_network_color_primary', false );
 			if ( $primary !== false ) {


### PR DESCRIPTION
This pull request includes a minor update to the `customize_register` function in the `inc/customizer/namespace.php` file. The change introduces a reference (`&`) to the `$color` variable in the `foreach` loop to allow modifications to the array elements directly.

This fix the customizer settings not having as default the primary color, and having `#b01109` instead

### How to test
1. Delete from `wp_options` the row with option_name `pb_network_color_header_links`
2. Reload the customizer and the header_links default color should be the primary color on the color picker selector