### PR TITLE
chore: translations update from Pressbooks Weblate

### DIFF
--- a/languages/bg_BG.po
+++ b/languages/bg_BG.po
@@ -2,19 +2,21 @@
 # This file is distributed under the GNU GPL v3 or later.
 # Translators:
 # Radost G <radosvetagiuleva@abv.bg>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Radost G <radosvetagiuleva@abv.bg>, 2024\n"
-"Language-Team: Bulgarian (Bulgaria) (https://app.transifex.com/pressbooks/teams/9194/bg_BG/)\n"
+"Language-Team: Bulgarian (Bulgaria) (https://app.transifex.com/pressbooks/"
+"teams/9194/bg_BG/)\n"
+"Language: bg_BG\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: bg_BG\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
@@ -36,9 +38,9 @@ msgid ""
 "named for the Aldine Press, founded by Aldus Manutius in 1494, who is "
 "regarded by many as the world’s first publisher."
 msgstr ""
-"Алдин е темата по подразбиране за началната страница на Платформата. Името е"
-" вдъхновено от Aldine Press, основана от Aldus Manutius през 1494 г., "
-"(смятан от мнозина за първи издател в света)."
+"Алдин е темата по подразбиране за началната страница на Платформата. Името е "
+"вдъхновено от Aldine Press, основана от Aldus Manutius през 1494 г., (смятан "
+"от мнозина за първи издател в света)."
 
 #. Author of the theme
 #: style.css
@@ -275,8 +277,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -303,8 +304,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -400,8 +400,8 @@ msgstr "Цвят на акцента (задръжте курсора на ми�
 #: inc/customizer/namespace.php:99
 msgid "Variant of the accent color, used for secondary element hover states."
 msgstr ""
-"Вариант на цвета на акцента, използван за състояния на задържане на вторичен"
-" елемент."
+"Вариант на цвета на акцента, използван за състояния на задържане на вторичен "
+"елемент."
 
 #: inc/customizer/namespace.php:104
 msgid "Primary Foreground Color"
@@ -610,7 +610,8 @@ msgstr "Няма открит разултат"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr "Готови да публикувате Вашия първи пост? Започнете тук."
 
 #: partials/content-none.php:41

--- a/languages/de_CH.po
+++ b/languages/de_CH.po
@@ -4,19 +4,21 @@
 # nebulon42, 2024
 # Steel Wagstaff <steel@pressbooks.com>, 2024
 # Thomas Dumm <thomas.dumm@delivros-orellfuessli.ch>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Thomas Dumm <thomas.dumm@delivros-orellfuessli.ch>, 2024\n"
-"Language-Team: German (Switzerland) (https://app.transifex.com/pressbooks/teams/9194/de_CH/)\n"
+"Language-Team: German (Switzerland) (https://app.transifex.com/pressbooks/"
+"teams/9194/de_CH/)\n"
+"Language: de_CH\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de_CH\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
@@ -222,8 +224,7 @@ msgid ""
 "in all the formats you need to publish."
 msgstr ""
 "Pressbooks ist eine einfach zu bedienende Software zum Erstellen von "
-"Büchern, mit der Sie ein Buch in allen gewünschten Formaten erstellen "
-"können."
+"Büchern, mit der Sie ein Buch in allen gewünschten Formaten erstellen können."
 
 #: inc/activation/namespace.php:30
 msgid "Learn More"
@@ -274,8 +275,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -302,8 +302,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -610,7 +609,8 @@ msgstr "Nichts gefunden"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr ""
 "Bereit Ihren ersten Beitrag zu veröffentlichen? <a href=\"%1$s\">Fangen Sie "
 "hier an</a>."
@@ -620,8 +620,8 @@ msgid ""
 "Sorry, but nothing matched your search terms. Please try again with some "
 "different keywords."
 msgstr ""
-"Entschuldigung, aber nichts passt auf Ihre Suchbegriffe. Bitte versuchen Sie"
-" es erneut mit anderen Schlagwörtern."
+"Entschuldigung, aber nichts passt auf Ihre Suchbegriffe. Bitte versuchen Sie "
+"es erneut mit anderen Schlagwörtern."
 
 #: partials/content-none.php:48
 msgid ""

--- a/languages/de_DE.po
+++ b/languages/de_DE.po
@@ -3,19 +3,21 @@
 # Translators:
 # Steel Wagstaff <steel@pressbooks.com>, 2024
 # Thomas Dumm <thomas.dumm@delivros-orellfuessli.ch>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Thomas Dumm <thomas.dumm@delivros-orellfuessli.ch>, 2024\n"
-"Language-Team: German (Germany) (https://app.transifex.com/pressbooks/teams/9194/de_DE/)\n"
+"Language-Team: German (Germany) (https://app.transifex.com/pressbooks/teams/"
+"9194/de_DE/)\n"
+"Language: de_DE\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: de_DE\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
@@ -221,8 +223,7 @@ msgid ""
 "in all the formats you need to publish."
 msgstr ""
 "Pressbooks ist eine einfach zu bedienende Software zum Erstellen von "
-"Büchern, mit der Sie ein Buch in allen gewünschten Formaten erstellen "
-"können."
+"Büchern, mit der Sie ein Buch in allen gewünschten Formaten erstellen können."
 
 #: inc/activation/namespace.php:30
 msgid "Learn More"
@@ -273,8 +274,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -301,8 +301,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -609,7 +608,8 @@ msgstr "Nichts gefunden"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr ""
 "Bereit Ihren ersten Beitrag zu veröffentlichen? <a href=\"%1$s\">Fangen Sie "
 "hier an</a>."
@@ -619,8 +619,8 @@ msgid ""
 "Sorry, but nothing matched your search terms. Please try again with some "
 "different keywords."
 msgstr ""
-"Entschuldigung, aber nichts passt auf Ihre Suchbegriffe. Bitte versuchen Sie"
-" es erneut mit anderen Schlagwörtern."
+"Entschuldigung, aber nichts passt auf Ihre Suchbegriffe. Bitte versuchen Sie "
+"es erneut mit anderen Schlagwörtern."
 
 #: partials/content-none.php:48
 msgid ""

--- a/languages/en_CA.po
+++ b/languages/en_CA.po
@@ -2,19 +2,21 @@
 # This file is distributed under the GNU GPL v3 or later.
 # Translators:
 # Steel Wagstaff <steel@pressbooks.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Steel Wagstaff <steel@pressbooks.com>, 2024\n"
-"Language-Team: English (Canada) (https://app.transifex.com/pressbooks/teams/9194/en_CA/)\n"
+"Language-Team: English (Canada) (https://app.transifex.com/pressbooks/teams/"
+"9194/en_CA/)\n"
+"Language: en_CA\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_CA\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
@@ -270,8 +272,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -298,8 +299,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -391,8 +391,7 @@ msgstr "Accent Colour (Hover)"
 
 #: inc/customizer/namespace.php:99
 msgid "Variant of the accent color, used for secondary element hover states."
-msgstr ""
-"Variant of the accent colour, used for secondary element hover states."
+msgstr "Variant of the accent colour, used for secondary element hover states."
 
 #: inc/customizer/namespace.php:104
 msgid "Primary Foreground Color"
@@ -601,8 +600,10 @@ msgstr "Nothing Found"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
-msgstr "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgstr ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 
 #: partials/content-none.php:41
 msgid ""

--- a/languages/en_GB.po
+++ b/languages/en_GB.po
@@ -2,19 +2,21 @@
 # This file is distributed under the GNU GPL v3 or later.
 # Translators:
 # Steel Wagstaff <steel@pressbooks.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Steel Wagstaff <steel@pressbooks.com>, 2024\n"
-"Language-Team: English (United Kingdom) (https://app.transifex.com/pressbooks/teams/9194/en_GB/)\n"
+"Language-Team: English (United Kingdom) (https://app.transifex.com/"
+"pressbooks/teams/9194/en_GB/)\n"
+"Language: en_GB\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: en_GB\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
@@ -270,8 +272,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -298,8 +299,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -391,8 +391,7 @@ msgstr "Accent Colour (Hover)"
 
 #: inc/customizer/namespace.php:99
 msgid "Variant of the accent color, used for secondary element hover states."
-msgstr ""
-"Variant of the accent colour, used for secondary element hover states."
+msgstr "Variant of the accent colour, used for secondary element hover states."
 
 #: inc/customizer/namespace.php:104
 msgid "Primary Foreground Color"
@@ -601,8 +600,10 @@ msgstr "Nothing Found"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
-msgstr "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgstr ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 
 #: partials/content-none.php:41
 msgid ""

--- a/languages/es_ES.po
+++ b/languages/es_ES.po
@@ -3,20 +3,23 @@
 # Translators:
 # Antonio D., 2018
 # Eduardo Vera, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Eduardo Vera, 2024\n"
-"Language-Team: Spanish (https://app.transifex.com/pressbooks/teams/9194/es/)\n"
+"Language-Team: Spanish (https://app.transifex.com/pressbooks/teams/9194/"
+"es/)\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: es\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
 
@@ -286,17 +289,16 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr "guía de usuario de Pressbooks"
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
 "updates on the %1$s. If you’re just getting started with Pressbooks, this "
 "%2$s will guide you."
 msgstr ""
-"Puedes encontrar videotutoriales cortos y webinarios sobre características y"
-" actualizaciones del producto en el %1$s. Si apenas estás dando tus primeros"
-" pasos en Pressbooks, esta %2$s te guiará."
+"Puedes encontrar videotutoriales cortos y webinarios sobre características y "
+"actualizaciones del producto en el %1$s. Si apenas estás dando tus primeros "
+"pasos en Pressbooks, esta %2$s te guiará."
 
 #: inc/activation/namespace.php:67
 msgid "Pressbooks YouTube channel"
@@ -319,8 +321,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr "webinarios mensuales"
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -347,8 +348,8 @@ msgid ""
 "fill out the %s to be put in touch with them."
 msgstr ""
 "Si necesitas soporte adicional, contacta con los administradores de la red "
-"de Pressbooks de tu institución. Si no sabes quiénes son los administradores"
-" de tu red, rellena el %s para ponerte en contacto con ellos."
+"de Pressbooks de tu institución. Si no sabes quiénes son los administradores "
+"de tu red, rellena el %s para ponerte en contacto con ellos."
 
 #: inc/activation/namespace.php:84
 msgid "support request form"
@@ -634,7 +635,8 @@ msgstr "No se ha encontrado nada"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr ""
 "¿Quieres publicar tu primera entrada? <a href=\"%1$s\">Empieza por aquí</a>."
 

--- a/languages/fr_FR.po
+++ b/languages/fr_FR.po
@@ -9,20 +9,22 @@
 # Dac Chartrand <dac@pressbooks.com>, 2019
 # Steel Wagstaff <steel@pressbooks.com>, 2022
 # MMOUNA MOUM, 2022
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: MMOUNA MOUM, 2022\n"
 "Language-Team: French (https://app.transifex.com/pressbooks/teams/9194/fr/)\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: fr\n"
-"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=(n == 0 || n == 1) ? 0 : n != 0 && n % "
+"1000000 == 0 ? 1 : 2;\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
 
@@ -182,8 +184,8 @@ msgstr "Bas de page du réseau, bloc 2"
 msgid ""
 "This page displays your network catalog, so there is no content to edit."
 msgstr ""
-"Votre catalogue réseau s&rsquo;affiche sur cette page, il n&rsquo;y a pas de"
-" contenu à modifier."
+"Votre catalogue réseau s&rsquo;affiche sur cette page, il n&rsquo;y a pas de "
+"contenu à modifier."
 
 #: inc/actions/namespace.php:295
 msgid "Page Section"
@@ -295,8 +297,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr "Guide de l'utilisateur de Pressbooks"
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -329,8 +330,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr "webinaires mensuels en ligne"
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -646,10 +646,11 @@ msgstr "Aucune résultat"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr ""
-"Prêt à publier votre première publication? <a href=\"%1$s\">Commencez "
-"ici</a>."
+"Prêt à publier votre première publication? <a href=\"%1$s\">Commencez ici</"
+"a>."
 
 #: partials/content-none.php:41
 msgid ""

--- a/languages/he.po
+++ b/languages/he.po
@@ -2,20 +2,22 @@
 # This file is distributed under the GNU GPL v3 or later.
 # Translators:
 # makeabook project <makeabookproject@gmail.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: makeabook project <makeabookproject@gmail.com>, 2024\n"
 "Language-Team: Hebrew (https://app.transifex.com/pressbooks/teams/9194/he/)\n"
+"Language: he\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: he\n"
-"Plural-Forms: nplurals=3; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % 1 == 0) ? 1: 2;\n"
+"Plural-Forms: nplurals=3; plural=(n == 1 && n % 1 == 0) ? 0 : (n == 2 && n % "
+"1 == 0) ? 1: 2;\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
 
@@ -265,8 +267,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -293,8 +294,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -595,7 +595,8 @@ msgstr ""
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr "מוכן לפרסום הפוסט הראשון שלך? <a href=\"%1$s\">Get started here</a>."
 
 #: partials/content-none.php:41

--- a/languages/hr.po
+++ b/languages/hr.po
@@ -2,20 +2,23 @@
 # This file is distributed under the GNU GPL v3 or later.
 # Translators:
 # Dubravko Cvikl <dcvikl@cvikl.hr>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Dubravko Cvikl <dcvikl@cvikl.hr>, 2024\n"
-"Language-Team: Croatian (Croatia) (https://app.transifex.com/pressbooks/teams/9194/hr_HR/)\n"
+"Language-Team: Croatian (Croatia) (https://app.transifex.com/pressbooks/"
+"teams/9194/hr_HR/)\n"
+"Language: hr_HR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hr_HR\n"
-"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2;\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
 
@@ -171,8 +174,7 @@ msgstr "Mrežni blok podnožja 2"
 #: inc/actions/namespace.php:238
 msgid ""
 "This page displays your network catalog, so there is no content to edit."
-msgstr ""
-"Ova stranica prikazuje katalog mreže tako nema sadržaja za uređivanje."
+msgstr "Ova stranica prikazuje katalog mreže tako nema sadržaja za uređivanje."
 
 #: inc/actions/namespace.php:295
 msgid "Page Section"
@@ -219,8 +221,8 @@ msgid ""
 "Pressbooks is easy-to-use book writing software that lets you create a book "
 "in all the formats you need to publish."
 msgstr ""
-"Presskooks je jednostavan za korištenje i omogućava Vam izradu knjiga u svim"
-" potrebnim formatima za objavljivanje."
+"Presskooks je jednostavan za korištenje i omogućava Vam izradu knjiga u svim "
+"potrebnim formatima za objavljivanje."
 
 #: inc/activation/namespace.php:30
 msgid "Learn More"
@@ -271,8 +273,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -299,8 +300,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -606,7 +606,8 @@ msgstr "Ništa nije pronađeno"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr "Spremni za Vašu prvu objavu? <a href=\"%1$s\">Započnite ovdje</a>."
 
 #: partials/content-none.php:41

--- a/languages/hu_HU.po
+++ b/languages/hu_HU.po
@@ -2,19 +2,21 @@
 # This file is distributed under the GNU GPL v3 or later.
 # Translators:
 # Antonio D., 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Antonio D., 2024\n"
-"Language-Team: Hungarian (Hungary) (https://app.transifex.com/pressbooks/teams/9194/hu_HU/)\n"
+"Language-Team: Hungarian (Hungary) (https://app.transifex.com/pressbooks/"
+"teams/9194/hu_HU/)\n"
+"Language: hu_HU\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: hu_HU\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
@@ -216,8 +218,8 @@ msgid ""
 "Pressbooks is easy-to-use book writing software that lets you create a book "
 "in all the formats you need to publish."
 msgstr ""
-"A Pressbooks egyszerűen használható könyvíró szoftver, amelynek segítségével"
-" könyveket készíthet, bármely formátumban."
+"A Pressbooks egyszerűen használható könyvíró szoftver, amelynek segítségével "
+"könyveket készíthet, bármely formátumban."
 
 #: inc/activation/namespace.php:30
 msgid "Learn More"
@@ -268,8 +270,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -296,8 +297,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -599,7 +599,8 @@ msgstr "Nincs Találat"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr ""
 
 #: partials/content-none.php:41

--- a/languages/it_IT.po
+++ b/languages/it_IT.po
@@ -4,20 +4,23 @@
 # Antonio D., 2018
 # Giuseppe Pignataro (Fastbyte01) <rogepix@gmail.com>, 2024
 # Steel Wagstaff <steel@pressbooks.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Steel Wagstaff <steel@pressbooks.com>, 2024\n"
-"Language-Team: Italian (https://app.transifex.com/pressbooks/teams/9194/it/)\n"
+"Language-Team: Italian (https://app.transifex.com/pressbooks/teams/9194/"
+"it/)\n"
+"Language: it\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: it\n"
-"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? 1 : 2;\n"
+"Plural-Forms: nplurals=3; plural=n == 1 ? 0 : n != 0 && n % 1000000 == 0 ? "
+"1 : 2;\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
 
@@ -219,8 +222,8 @@ msgid ""
 "Pressbooks is easy-to-use book writing software that lets you create a book "
 "in all the formats you need to publish."
 msgstr ""
-"Pressbooks è un software per scrivere libri facile da usare, che permette di"
-" creare un libro in qualsiasi formato di cui hai bisogno."
+"Pressbooks è un software per scrivere libri facile da usare, che permette di "
+"creare un libro in qualsiasi formato di cui hai bisogno."
 
 #: inc/activation/namespace.php:30
 msgid "Learn More"
@@ -271,8 +274,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -299,8 +301,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -606,7 +607,8 @@ msgstr "Nessun Risultato"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr ""
 
 #: partials/content-none.php:41

--- a/languages/ja.po
+++ b/languages/ja.po
@@ -2,19 +2,21 @@
 # This file is distributed under the GNU GPL v3 or later.
 # Translators:
 # Eduardo Vera, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Eduardo Vera, 2024\n"
-"Language-Team: Japanese (https://app.transifex.com/pressbooks/teams/9194/ja/)\n"
+"Language-Team: Japanese (https://app.transifex.com/pressbooks/teams/9194/"
+"ja/)\n"
+"Language: ja\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ja\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
@@ -36,8 +38,9 @@ msgid ""
 "named for the Aldine Press, founded by Aldus Manutius in 1494, who is "
 "regarded by many as the world’s first publisher."
 msgstr ""
-"Aldine は Pressbooks "
-"サイトネットワークのホームページのデフォルトテーマです。これは、多くの人に世界初の出版社とされるアルドゥス・マヌティウスが1494年に設立したアルド印刷所にちなんで名付けられました。"
+"Aldine は Pressbooks サイトネットワークのホームページのデフォルトテーマです。"
+"これは、多くの人に世界初の出版社とされるアルドゥス・マヌティウスが1494年に設"
+"立したアルド印刷所にちなんで名付けられました。"
 
 #. Author of the theme
 #: style.css
@@ -134,7 +137,9 @@ msgstr "依存関係が見つかりません"
 
 #: functions.php:20
 msgid "You must run <code>composer install</code> from the Aldine directory."
-msgstr "Aldine ディレクトリのルートから <code>composer install</code> を実行する必要があります。"
+msgstr ""
+"Aldine ディレクトリのルートから <code>composer install</code> を実行する必要"
+"があります。"
 
 #: header.php:50
 msgid "Skip to content"
@@ -168,7 +173,9 @@ msgstr "サイトネットワークのブロック2"
 #: inc/actions/namespace.php:238
 msgid ""
 "This page displays your network catalog, so there is no content to edit."
-msgstr "このページはサイトネットワークのカタログを表示するため、編集するコンテンツがありません。"
+msgstr ""
+"このページはサイトネットワークのカタログを表示するため、編集するコンテンツが"
+"ありません。"
 
 #: inc/actions/namespace.php:295
 msgid "Page Section"
@@ -214,7 +221,9 @@ msgstr "Pressbooks について"
 msgid ""
 "Pressbooks is easy-to-use book writing software that lets you create a book "
 "in all the formats you need to publish."
-msgstr "Pressbooks は本を使いやすい書くソフトウェアであり、すべての公開する必要な形式で本を作成できます。"
+msgstr ""
+"Pressbooks は本を使いやすい書くソフトウェアであり、すべての公開する必要な形式"
+"で本を作成できます。"
 
 #: inc/activation/namespace.php:30
 msgid "Learn More"
@@ -232,8 +241,9 @@ msgid ""
 "educational resources, textbooks, scholarly monographs, fiction and non-"
 "fiction books, white papers, syllabi, and more."
 msgstr ""
-"Pressbooks は本の簡単な制作ソフトウェアであり、自分のアイデアを簡単に書き、開発、共有できます。Pressbooks "
-"を使用して、オープン教育リソース、書籍、学術論文、フィクション・ノンフィクションの本、白書、シラバスなどを公開できます。"
+"Pressbooks は本の簡単な制作ソフトウェアであり、自分のアイデアを簡単に書き、開"
+"発、共有できます。Pressbooks を使用して、オープン教育リソース、書籍、学術論"
+"文、フィクション・ノンフィクションの本、白書、シラバスなどを公開できます。"
 
 #: inc/activation/namespace.php:43
 msgid ""
@@ -241,8 +251,9 @@ msgid ""
 "produce exports in multiple formats, including accessible EPUBs and PDFs "
 "specially designed for print-on-demand or digital distribution."
 msgstr ""
-"Pressbooks で作成者はウェブにコンテンツを素早く公開したり、オンデマンド印刷またはデジタル配信用に特別に設計されたアクセス可能な EPUB と"
-" PDF を含む複数の形式にエクスポートを作成したりできます。"
+"Pressbooks で作成者はウェブにコンテンツを素早く公開したり、オンデマンド印刷ま"
+"たはデジタル配信用に特別に設計されたアクセス可能な EPUB と PDF を含む複数の形"
+"式にエクスポートを作成したりできます。"
 
 #: inc/activation/namespace.php:47
 msgid "suite of products"
@@ -264,23 +275,23 @@ msgid ""
 "resource available is the %s, which contains everything you need to know "
 "about creating, enriching and exporting your work."
 msgstr ""
-"Pressbooks プロジェクトのヘルプをお探しですか ? "
-"利用可能な最も充実したリソースは%sです。作品を作成、強化、エクスポートについて知っておく必要があるすべてを含みます。"
+"Pressbooks プロジェクトのヘルプをお探しですか ? 利用可能な最も充実したリソー"
+"スは%sです。作品を作成、強化、エクスポートについて知っておく必要があるすべて"
+"を含みます。"
 
 #: inc/activation/namespace.php:62
 msgid "Pressbooks User Guide"
 msgstr "Pressbooks ユーザーガイド"
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
 "updates on the %1$s. If you’re just getting started with Pressbooks, this "
 "%2$s will guide you."
 msgstr ""
-"機能と製品更新について %1$sに短いビデオチュートリアルとウェビナーを表示できます。Pressbooks "
-"を始めたばかりの場合、この%2$sで進めます。"
+"機能と製品更新について %1$sに短いビデオチュートリアルとウェビナーを表示できま"
+"す。Pressbooks を始めたばかりの場合、この%2$sで進めます。"
 
 #: inc/activation/namespace.php:67
 msgid "Pressbooks YouTube channel"
@@ -295,22 +306,24 @@ msgstr "短いビデオシリーズ"
 msgid ""
 "If you learn best by learning by attending live training sessions, you can "
 "register for and attend one of Pressbooks' %s."
-msgstr "ライブトレーニングセッションに参加するのが一番よくわかったら、いずれかの Pressbooks の%sに登録と参加できます。"
+msgstr ""
+"ライブトレーニングセッションに参加するのが一番よくわかったら、いずれかの "
+"Pressbooks の%sに登録と参加できます。"
 
 #: inc/activation/namespace.php:73
 msgid "monthly webinars"
 msgstr "毎月のウェビナー"
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
 "answers to some commonly asked questions. Pressbooks also maintains a %2$s "
 "where you can ask and answer questions of other users."
 msgstr ""
-"%1$sにも他の役に立つサポートリソースへのリンクが含んで、いくつかのよく寄せられる質問の答えがあります。Pressbooks "
-"は質問して他のユーザーを返信できる%2$sも管理します。"
+"%1$sにも他の役に立つサポートリソースへのリンクが含んで、いくつかのよく寄せら"
+"れる質問の答えがあります。Pressbooks は質問して他のユーザーを返信できる%2$sも"
+"管理します。"
 
 #: inc/activation/namespace.php:78
 msgid "Pressbooks support page"
@@ -327,8 +340,9 @@ msgid ""
 "network managers. If you don’t know who your network managers are, please "
 "fill out the %s to be put in touch with them."
 msgstr ""
-"追加の必要なサポートについては、機関の Pressbooks "
-"サイトネットワーク管理者に連絡します。サイトネットワーク管理者がわからない場合、連絡するには%sを入力してください。"
+"追加の必要なサポートについては、機関の Pressbooks サイトネットワーク管理者に"
+"連絡します。サイトネットワーク管理者がわからない場合、連絡するには%sを入力し"
+"てください。"
 
 #: inc/activation/namespace.php:84
 msgid "support request form"
@@ -607,14 +621,19 @@ msgstr "何も見つかりませんでした"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
-msgstr "最初の投稿を公開する準備はできましたか ? <a href=\"%1$s\">ここから始めましょう</a>。"
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgstr ""
+"最初の投稿を公開する準備はできましたか ? <a href=\"%1$s\">ここから始めましょ"
+"う</a>。"
 
 #: partials/content-none.php:41
 msgid ""
 "Sorry, but nothing matched your search terms. Please try again with some "
 "different keywords."
-msgstr "検索キーワードに一致するものが見つかりませんでした。別のキーワードでもう一度お試しください。"
+msgstr ""
+"検索キーワードに一致するものが見つかりませんでした。別のキーワードでもう一度"
+"お試しください。"
 
 #: partials/content-none.php:48
 msgid ""

--- a/languages/kn.po
+++ b/languages/kn.po
@@ -2,19 +2,21 @@
 # This file is distributed under the GNU GPL v3 or later.
 # Translators:
 # Omshivaprakash H L <omshivaprakash@gmail.com>, 2022
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Omshivaprakash H L <omshivaprakash@gmail.com>, 2022\n"
-"Language-Team: Kannada (https://app.transifex.com/pressbooks/teams/9194/kn/)\n"
+"Language-Team: Kannada (https://app.transifex.com/pressbooks/teams/9194/"
+"kn/)\n"
+"Language: kn\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: kn\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
@@ -36,9 +38,9 @@ msgid ""
 "named for the Aldine Press, founded by Aldus Manutius in 1494, who is "
 "regarded by many as the world’s first publisher."
 msgstr ""
-"ಪ್ರೆಸ್‍ಬುಕ್ಸ್ ನೆಟ್‍ವರ್ಕ್ ಗಳ ಮುಖಪುಟಕ್ಕೆ ಆಲ್ಡಿನ್ ಡೀಫಾಲ್ಟ್ ವಿಷಯವಾಗಿದೆ. ಇದನ್ನು "
-"1494 ರಲ್ಲಿ ಆಲ್ಡಸ್ ಮ್ಯಾನುಟಿಯಸ್ ಸ್ಥಾಪಿಸಿದ ಆಲ್ಡಿನ್ ಪ್ರೆಸ್‍ಗೆ ಹೆಸರಿಸಲಾಗಿದೆ, "
-"ಇದನ್ನು ವಿಶ್ವದ ಮೊದಲ ಪ್ರಕಾಶಕರು ಎಂದು ಅನೇಕರು ಪರಿಗಣಿಸುತ್ತಾರೆ."
+"ಪ್ರೆಸ್‍ಬುಕ್ಸ್ ನೆಟ್‍ವರ್ಕ್ ಗಳ ಮುಖಪುಟಕ್ಕೆ ಆಲ್ಡಿನ್ ಡೀಫಾಲ್ಟ್ ವಿಷಯವಾಗಿದೆ. ಇದನ್ನು 1494 ರಲ್ಲಿ ಆಲ್ಡಸ್ "
+"ಮ್ಯಾನುಟಿಯಸ್ ಸ್ಥಾಪಿಸಿದ ಆಲ್ಡಿನ್ ಪ್ರೆಸ್‍ಗೆ ಹೆಸರಿಸಲಾಗಿದೆ, ಇದನ್ನು ವಿಶ್ವದ ಮೊದಲ ಪ್ರಕಾಶಕರು ಎಂದು "
+"ಅನೇಕರು ಪರಿಗಣಿಸುತ್ತಾರೆ."
 
 #. Author of the theme
 #: style.css
@@ -171,8 +173,8 @@ msgstr "ನೆಟ್ವರ್ಕ್ ಫೂಟರ್ ಬ್ಲಾಕ್ 2"
 msgid ""
 "This page displays your network catalog, so there is no content to edit."
 msgstr ""
-"ಈ ಪುಟವು ನಿಮ್ಮ ನೆಟ್ವರ್ಕ್ ಕ್ಯಾಟಲಾಗ್ ಅನ್ನು ಪ್ರದರ್ಶಿಸುತ್ತದೆ, ಆದ್ದರಿಂದ ಸಂಪಾದಿಸಲು "
-"ಯಾವುದೇ ವಿಷಯವಿಲ್ಲ."
+"ಈ ಪುಟವು ನಿಮ್ಮ ನೆಟ್ವರ್ಕ್ ಕ್ಯಾಟಲಾಗ್ ಅನ್ನು ಪ್ರದರ್ಶಿಸುತ್ತದೆ, ಆದ್ದರಿಂದ ಸಂಪಾದಿಸಲು ಯಾವುದೇ "
+"ವಿಷಯವಿಲ್ಲ."
 
 #: inc/actions/namespace.php:295
 msgid "Page Section"
@@ -219,8 +221,8 @@ msgid ""
 "Pressbooks is easy-to-use book writing software that lets you create a book "
 "in all the formats you need to publish."
 msgstr ""
-"ಪ್ರೆಸ್‍ಬುಕ್ಸ್ ಸುಲಭವಾಗಿ ಬಳಸಬಹುದಾದ ಪುಸ್ತಕ ಬರೆಯುವ ಸಾಫ್ಟ್ ವೇರ್ ಆಗಿದ್ದು, ನೀವು "
-"ಪ್ರಕಟಿಸಬೇಕಾದ ಎಲ್ಲಾ ಸ್ವರೂಪಗಳಲ್ಲಿ ಪುಸ್ತಕವನ್ನು ರಚಿಸಲು ನಿಮಗೆ ಅವಕಾಶ ನೀಡುತ್ತದೆ."
+"ಪ್ರೆಸ್‍ಬುಕ್ಸ್ ಸುಲಭವಾಗಿ ಬಳಸಬಹುದಾದ ಪುಸ್ತಕ ಬರೆಯುವ ಸಾಫ್ಟ್ ವೇರ್ ಆಗಿದ್ದು, ನೀವು ಪ್ರಕಟಿಸಬೇಕಾದ "
+"ಎಲ್ಲಾ ಸ್ವರೂಪಗಳಲ್ಲಿ ಪುಸ್ತಕವನ್ನು ರಚಿಸಲು ನಿಮಗೆ ಅವಕಾಶ ನೀಡುತ್ತದೆ."
 
 #: inc/activation/namespace.php:30
 msgid "Learn More"
@@ -271,8 +273,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -299,8 +300,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -344,8 +344,7 @@ msgstr "ಕ್ಯಾಟಲಾಗ್ ನವೀಕರಿಸಲಾಗಿದೆ."
 
 #: inc/admin/namespace.php:38
 msgid "Sorry, but your catalog was not updated. Please try again."
-msgstr ""
-"ಕ್ಷಮಿಸಿ, ಆದರೆ ನಿಮ್ಮ ಕ್ಯಾಟಲಾಗ್ ನವೀಕರಿಸಲಾಗಿಲ್ಲ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ."
+msgstr "ಕ್ಷಮಿಸಿ, ಆದರೆ ನಿಮ್ಮ ಕ್ಯಾಟಲಾಗ್ ನವೀಕರಿಸಲಾಗಿಲ್ಲ. ದಯವಿಟ್ಟು ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ."
 
 #: inc/admin/namespace.php:39
 msgid "Dismiss this notice."
@@ -602,26 +601,26 @@ msgstr "ಏನೂ ಸಿಗಲಿಲ್ಲ"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr ""
-"ನಿಮ್ಮ ಮೊದಲ ಪೋಸ್ಟ್ ಪ್ರಕಟಿಸಲು ಸಿದ್ಧರಿದ್ದೀರಾ? <a href=\"%1$s\">ಇಲ್ಲಿ "
-"ಪ್ರಾರಂಭಿಸಿ</a>."
+"ನಿಮ್ಮ ಮೊದಲ ಪೋಸ್ಟ್ ಪ್ರಕಟಿಸಲು ಸಿದ್ಧರಿದ್ದೀರಾ? <a href=\"%1$s\">ಇಲ್ಲಿ ಪ್ರಾರಂಭಿಸಿ</a>."
 
 #: partials/content-none.php:41
 msgid ""
 "Sorry, but nothing matched your search terms. Please try again with some "
 "different keywords."
 msgstr ""
-"ಕ್ಷಮಿಸಿ, ಆದರೆ ನಿಮ್ಮ ಹುಡುಕಾಟದ ನಿಯಮಗಳಿಗೆ ಯಾವುದೂ ಹೊಂದಿಕೆಯಾಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು "
-"ಕೆಲವು ವಿಭಿನ್ನ ಕೀವರ್ಡ್ ಗಳೊಂದಿಗೆ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ."
+"ಕ್ಷಮಿಸಿ, ಆದರೆ ನಿಮ್ಮ ಹುಡುಕಾಟದ ನಿಯಮಗಳಿಗೆ ಯಾವುದೂ ಹೊಂದಿಕೆಯಾಗಲಿಲ್ಲ. ದಯವಿಟ್ಟು ಕೆಲವು "
+"ವಿಭಿನ್ನ ಕೀವರ್ಡ್ ಗಳೊಂದಿಗೆ ಮತ್ತೆ ಪ್ರಯತ್ನಿಸಿ."
 
 #: partials/content-none.php:48
 msgid ""
 "It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps "
 "searching can help."
 msgstr ""
-"ನೀವು ಹುಡುಕುತ್ತಿರುವುದನ್ನು ನಾವು ಕಂಡುಹಿಡಿಯಲು ಸಾಧ್ಯವಿಲ್ಲ ಎಂದು ತೋರುತ್ತದೆ. ಬಹುಶಃ "
-"ಶೋಧವು ಸಹಾಯ ಮಾಡಬಹುದು."
+"ನೀವು ಹುಡುಕುತ್ತಿರುವುದನ್ನು ನಾವು ಕಂಡುಹಿಡಿಯಲು ಸಾಧ್ಯವಿಲ್ಲ ಎಂದು ತೋರುತ್ತದೆ. ಬಹುಶಃ ಶೋಧವು "
+"ಸಹಾಯ ಮಾಡಬಹುದು."
 
 #: partials/content-page-catalog.php:17
 msgid "Filter by Subject"

--- a/languages/lt_LT.po
+++ b/languages/lt_LT.po
@@ -2,20 +2,24 @@
 # This file is distributed under the GNU GPL v3 or later.
 # Translators:
 # Antonio D., 2018
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Antonio D., 2018\n"
-"Language-Team: Lithuanian (Lithuania) (https://app.transifex.com/pressbooks/teams/9194/lt_LT/)\n"
+"Language-Team: Lithuanian (Lithuania) (https://app.transifex.com/pressbooks/"
+"teams/9194/lt_LT/)\n"
+"Language: lt_LT\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: lt_LT\n"
-"Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < 11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? 1 : n % 1 != 0 ? 2: 3);\n"
+"Plural-Forms: nplurals=4; plural=(n % 10 == 1 && (n % 100 > 19 || n % 100 < "
+"11) ? 0 : (n % 10 >= 2 && n % 10 <=9) && (n % 100 > 19 || n % 100 < 11) ? "
+"1 : n % 1 != 0 ? 2: 3);\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
 
@@ -270,8 +274,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -298,8 +301,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -603,7 +605,8 @@ msgstr "Nieko Nerasta"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr ""
 
 #: partials/content-none.php:41

--- a/languages/lv.po
+++ b/languages/lv.po
@@ -2,20 +2,23 @@
 # This file is distributed under the GNU GPL v3 or later.
 # Translators:
 # Antonio D., 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Antonio D., 2024\n"
-"Language-Team: Latvian (https://app.transifex.com/pressbooks/teams/9194/lv/)\n"
+"Language-Team: Latvian (https://app.transifex.com/pressbooks/teams/9194/"
+"lv/)\n"
+"Language: lv\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: lv\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : "
+"2);\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
 
@@ -217,8 +220,8 @@ msgid ""
 "Pressbooks is easy-to-use book writing software that lets you create a book "
 "in all the formats you need to publish."
 msgstr ""
-"Pressbooks vietne ir viegli lietojama grāmatu rakstīšanas programmatūra, kas"
-" ļauj Jums izveidot grāmatu jebkurā formātā, kādā Jums ir nepieciešams to "
+"Pressbooks vietne ir viegli lietojama grāmatu rakstīšanas programmatūra, kas "
+"ļauj Jums izveidot grāmatu jebkurā formātā, kādā Jums ir nepieciešams to "
 "publicēt."
 
 #: inc/activation/namespace.php:30
@@ -270,8 +273,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -298,8 +300,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -606,7 +607,8 @@ msgstr "Nekas nebija atrasts "
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr ""
 
 #: partials/content-none.php:41

--- a/languages/nl_NL.po
+++ b/languages/nl_NL.po
@@ -2,19 +2,21 @@
 # This file is distributed under the GNU GPL v3 or later.
 # Translators:
 # Nienke Coppens <nienke.coppens@gmail.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Nienke Coppens <nienke.coppens@gmail.com>, 2024\n"
-"Language-Team: Dutch (Netherlands) (https://app.transifex.com/pressbooks/teams/9194/nl_NL/)\n"
+"Language-Team: Dutch (Netherlands) (https://app.transifex.com/pressbooks/"
+"teams/9194/nl_NL/)\n"
+"Language: nl_NL\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: nl_NL\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
@@ -37,8 +39,8 @@ msgid ""
 "regarded by many as the world’s first publisher."
 msgstr ""
 "Aldine is het standaard thema voor de home pagina van Pressbooks netwerken. "
-"Het is vernoemd naar de Aldine Press, opgericht door Aldus Manutios in 1494,"
-" die gezien wordt door velen als &acute;s wereld&acute;s eerste uitgever."
+"Het is vernoemd naar de Aldine Press, opgericht door Aldus Manutios in 1494, "
+"die gezien wordt door velen als &acute;s wereld&acute;s eerste uitgever."
 
 #. Author of the theme
 #: style.css
@@ -270,8 +272,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -298,8 +299,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -378,8 +378,7 @@ msgstr "Primaire Kleur (Zwevend)"
 #: inc/customizer/namespace.php:87
 msgid "Variant of the primary color, used for primary element hover states."
 msgstr ""
-"Variant van de primaire kleur, gebruikt voor primaire element "
-"zweefstatussen."
+"Variant van de primaire kleur, gebruikt voor primaire element zweefstatussen."
 
 #: inc/customizer/namespace.php:92
 msgid "Accent Color"
@@ -387,8 +386,7 @@ msgstr "Accent Kleur"
 
 #: inc/customizer/namespace.php:93
 msgid "Accent color, used for flourishes and secondary elements."
-msgstr ""
-"Accentkleur, gebruikt voor verfraai&iuml;ngen en secundaire elementen."
+msgstr "Accentkleur, gebruikt voor verfraai&iuml;ngen en secundaire elementen."
 
 #: inc/customizer/namespace.php:98
 msgid "Accent Color (Hover)"
@@ -397,8 +395,7 @@ msgstr "Accenkleur (Zwevend)"
 #: inc/customizer/namespace.php:99
 msgid "Variant of the accent color, used for secondary element hover states."
 msgstr ""
-"Variant van de accentkleur, gebruikt voor secundaire element zweef "
-"statussen."
+"Variant van de accentkleur, gebruikt voor secundaire element zweef statussen."
 
 #: inc/customizer/namespace.php:104
 msgid "Primary Foreground Color"
@@ -607,7 +604,8 @@ msgstr "Niets gevonden"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr ""
 "Klaar om uw eerste bericht te publiceren? <a href=\"%1$s\">Begin hier</a>."
 

--- a/languages/ru_RU.po
+++ b/languages/ru_RU.po
@@ -2,20 +2,24 @@
 # This file is distributed under the GNU GPL v3 or later.
 # Translators:
 # Antonio D., 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Antonio D., 2024\n"
-"Language-Team: Russian (https://app.transifex.com/pressbooks/teams/9194/ru/)\n"
+"Language-Team: Russian (https://app.transifex.com/pressbooks/teams/9194/"
+"ru/)\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: ru\n"
-"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n%100>=11 && n%100<=14)? 2 : 3);\n"
+"Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || "
+"(n%100>=11 && n%100<=14)? 2 : 3);\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
 
@@ -271,8 +275,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -299,8 +302,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr ""
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -378,8 +380,7 @@ msgstr "Основной цвет (при наведении)"
 #: inc/customizer/namespace.php:87
 msgid "Variant of the primary color, used for primary element hover states."
 msgstr ""
-"Вариация основного цвета, используемого для основных элементов при "
-"наведении."
+"Вариация основного цвета, используемого для основных элементов при наведении."
 
 #: inc/customizer/namespace.php:92
 msgid "Accent Color"
@@ -607,7 +608,8 @@ msgstr "Ничего не найдено"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr ""
 
 #: partials/content-none.php:41
@@ -623,8 +625,8 @@ msgid ""
 "It seems we can&rsquo;t find what you&rsquo;re looking for. Perhaps "
 "searching can help."
 msgstr ""
-"Кажется, мы не можем найти того, что Вы ищите. Возможно, Вам поможет функция"
-" поиска."
+"Кажется, мы не можем найти того, что Вы ищите. Возможно, Вам поможет функция "
+"поиска."
 
 #: partials/content-page-catalog.php:17
 msgid "Filter by Subject"

--- a/languages/tr_TR.po
+++ b/languages/tr_TR.po
@@ -3,19 +3,21 @@
 # Translators:
 # Mustafa Bulun <mustafa.bulun@bizimajans.com>, 2020
 # Zeki Tuman (ztuman) <afuatdemir@gmail.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: Zeki Tuman (ztuman) <afuatdemir@gmail.com>, 2024\n"
-"Language-Team: Turkish (Turkey) (https://app.transifex.com/pressbooks/teams/9194/tr_TR/)\n"
+"Language-Team: Turkish (Turkey) (https://app.transifex.com/pressbooks/teams/"
+"9194/tr_TR/)\n"
+"Language: tr_TR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: tr_TR\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
@@ -240,8 +242,8 @@ msgid ""
 msgstr ""
 "Pressbooks, fikirlerinizi yazmayı, geliştirmeyi ve paylaşmayı kolaylaştıran "
 "basit bir kitap yazma yazılımıdır. Açık eğitim kaynakları, ders kitapları, "
-"bilimsel monografiler, kurgu ve kurgu olmayan kitapları, teknik incelemeler,"
-" ders programları ve daha fazlasını yayınlamak için Pressbooks'u "
+"bilimsel monografiler, kurgu ve kurgu olmayan kitapları, teknik incelemeler, "
+"ders programları ve daha fazlasını yayınlamak için Pressbooks'u "
 "kullanabilirsiniz."
 
 #: inc/activation/namespace.php:43
@@ -250,8 +252,8 @@ msgid ""
 "produce exports in multiple formats, including accessible EPUBs and PDFs "
 "specially designed for print-on-demand or digital distribution."
 msgstr ""
-"Pressbooks, içerik oluşturucuların içeriklerini hızla web'de yayınlamalarına"
-" ve isteğe bağlı olarak baskı veya dijital dağıtım için özel olarak "
+"Pressbooks, içerik oluşturucuların içeriklerini hızla web'de yayınlamalarına "
+"ve isteğe bağlı olarak baskı veya dijital dağıtım için özel olarak "
 "tasarlanmış erişilebilir EPUB'lar ve PDF'ler dahil olmak üzere birden çok "
 "biçimde indirilebilir dosyalar üretmelerine imkan tanır."
 
@@ -283,8 +285,7 @@ msgstr ""
 msgid "Pressbooks User Guide"
 msgstr "Pressbooks Kullanıcı Kılavuzu "
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
@@ -316,8 +317,7 @@ msgstr ""
 msgid "monthly webinars"
 msgstr "aylık webinarlar "
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
@@ -627,10 +627,11 @@ msgstr "Hiçbirşey Bulunamadı"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr ""
-"İlk paylaşımını yapmak için hazır mısın? <a href=\"%1$s\">Buradan "
-"başlayın</a>."
+"İlk paylaşımını yapmak için hazır mısın? <a href=\"%1$s\">Buradan başlayın</"
+"a>."
 
 #: partials/content-none.php:41
 msgid ""

--- a/languages/zh_CN.po
+++ b/languages/zh_CN.po
@@ -3,19 +3,21 @@
 # Translators:
 # jin peng <hp3240au@gmail.com>, 2019
 # fish free <winofchina@hotmail.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: fish free <winofchina@hotmail.com>, 2024\n"
-"Language-Team: Chinese (China) (https://app.transifex.com/pressbooks/teams/9194/zh_CN/)\n"
+"Language-Team: Chinese (China) (https://app.transifex.com/pressbooks/teams/"
+"9194/zh_CN/)\n"
+"Language: zh_CN\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_CN\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
@@ -37,8 +39,8 @@ msgid ""
 "named for the Aldine Press, founded by Aldus Manutius in 1494, who is "
 "regarded by many as the world’s first publisher."
 msgstr ""
-"Aldine 是 Pressbooks 网络主页的默认主题。它以 Aldine 出版社命名，该出版社由 Aldus Manutius 于 1494 "
-"年创立，被许多人视为世界上第一位出版商。"
+"Aldine 是 Pressbooks 网络主页的默认主题。它以 Aldine 出版社命名，该出版社由 "
+"Aldus Manutius 于 1494 年创立，被许多人视为世界上第一位出版商。"
 
 #. Author of the theme
 #: style.css
@@ -215,7 +217,8 @@ msgstr "关于Pressbooks"
 msgid ""
 "Pressbooks is easy-to-use book writing software that lets you create a book "
 "in all the formats you need to publish."
-msgstr "Pressbooks 是一款易于使用的图书写作软件，可让您创建需要发布的所有格式的图书。"
+msgstr ""
+"Pressbooks 是一款易于使用的图书写作软件，可让您创建需要发布的所有格式的图书。"
 
 #: inc/activation/namespace.php:30
 msgid "Learn More"
@@ -233,8 +236,9 @@ msgid ""
 "educational resources, textbooks, scholarly monographs, fiction and non-"
 "fiction books, white papers, syllabi, and more."
 msgstr ""
-"Pressbooks 是一款简单的图书制作软件，可让您轻松编写、开发和分享您的想法。您可以使用 Pressbooks "
-"发布开放教育资源、教科书、学术专著、小说和非小说类书籍、白皮书、教学大纲等。"
+"Pressbooks 是一款简单的图书制作软件，可让您轻松编写、开发和分享您的想法。您可"
+"以使用 Pressbooks 发布开放教育资源、教科书、学术专著、小说和非小说类书籍、白"
+"皮书、教学大纲等。"
 
 #: inc/activation/namespace.php:43
 msgid ""
@@ -242,7 +246,8 @@ msgid ""
 "produce exports in multiple formats, including accessible EPUBs and PDFs "
 "specially designed for print-on-demand or digital distribution."
 msgstr ""
-"Pressbooks 让创作者能够快速将其内容发布到网络上并以多种格式导出，包括专为按需印刷或数字发行而设计的可访问 EPUB 和 PDF。"
+"Pressbooks 让创作者能够快速将其内容发布到网络上并以多种格式导出，包括专为按需"
+"印刷或数字发行而设计的可访问 EPUB 和 PDF。"
 
 #: inc/activation/namespace.php:47
 msgid "suite of products"
@@ -263,20 +268,23 @@ msgid ""
 "Are you looking for help on your Pressbooks project? The most comprehensive "
 "resource available is the %s, which contains everything you need to know "
 "about creating, enriching and exporting your work."
-msgstr "您是否在寻求有关 Pressbooks 项目的帮助？最全面的资源是%s ，其中包含有关创建、丰富和导出作品所需了解的一切。"
+msgstr ""
+"您是否在寻求有关 Pressbooks 项目的帮助？最全面的资源是%s ，其中包含有关创建、"
+"丰富和导出作品所需了解的一切。"
 
 #: inc/activation/namespace.php:62
 msgid "Pressbooks User Guide"
 msgstr "Pressbooks用户指南"
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
 "updates on the %1$s. If you’re just getting started with Pressbooks, this "
 "%2$s will guide you."
-msgstr "您可以在%1$s上找到有关功能和产品更新的简短视频教程和网络研讨会。如果您刚刚开始使用 Pressbooks，此%2$s将为您提供指导。"
+msgstr ""
+"您可以在%1$s上找到有关功能和产品更新的简短视频教程和网络研讨会。如果您刚刚开"
+"始使用 Pressbooks，此%2$s将为您提供指导。"
 
 #: inc/activation/namespace.php:67
 msgid "Pressbooks YouTube channel"
@@ -291,21 +299,23 @@ msgstr "短视频系列"
 msgid ""
 "If you learn best by learning by attending live training sessions, you can "
 "register for and attend one of Pressbooks' %s."
-msgstr "如果您通过参加现场培训课程获得最佳学习效果，您可以注册并参加 Pressbooks 的%s中一项课程。"
+msgstr ""
+"如果您通过参加现场培训课程获得最佳学习效果，您可以注册并参加 Pressbooks 的%s"
+"中一项课程。"
 
 #: inc/activation/namespace.php:73
 msgid "monthly webinars"
 msgstr "阅读研讨会"
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
 "answers to some commonly asked questions. Pressbooks also maintains a %2$s "
 "where you can ask and answer questions of other users."
 msgstr ""
-"%1$s还包含指向其他有用支持资源的链接，并回答一些常见问题。Pressbooks 还维护一个%2$s，您可以在其中提问和回答其他用户的问题。"
+"%1$s还包含指向其他有用支持资源的链接，并回答一些常见问题。Pressbooks 还维护一"
+"个%2$s，您可以在其中提问和回答其他用户的问题。"
 
 #: inc/activation/namespace.php:78
 msgid "Pressbooks support page"
@@ -321,7 +331,9 @@ msgid ""
 "For additional support needs, reach out to your institution’s Pressbooks "
 "network managers. If you don’t know who your network managers are, please "
 "fill out the %s to be put in touch with them."
-msgstr "如需更多支持，请联系您所在机构的 Pressbooks 网络管理员。如果您不知道您的网络管理员是谁，请填写表格%s以便与他们取得联系。"
+msgstr ""
+"如需更多支持，请联系您所在机构的 Pressbooks 网络管理员。如果您不知道您的网络"
+"管理员是谁，请填写表格%s以便与他们取得联系。"
 
 #: inc/activation/namespace.php:84
 msgid "support request form"
@@ -600,7 +612,8 @@ msgstr "未找到任何东西"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr "准备好发布了吗？ <a href=\"%1$s\">点此开始</a>。"
 
 #: partials/content-none.php:41

--- a/languages/zh_TW.po
+++ b/languages/zh_TW.po
@@ -3,19 +3,21 @@
 # Translators:
 # jin peng <hp3240au@gmail.com>, 2024
 # fish free <winofchina@hotmail.com>, 2024
-# 
+#
 msgid ""
 msgstr ""
 "Project-Id-Version: Aldine 1.19.2\n"
-"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/issues\n"
-"POT-Creation-Date: 2024-12-19T16:42:12+00:00\n"
+"Report-Msgid-Bugs-To: https://github.com/pressbooks/pressbooks-aldine/"
+"issues\n"
+"POT-Creation-Date: 2025-01-27T15:33:57+00:00\n"
 "PO-Revision-Date: 2018-03-06 14:24+0000\n"
 "Last-Translator: fish free <winofchina@hotmail.com>, 2024\n"
-"Language-Team: Chinese (Taiwan) (https://app.transifex.com/pressbooks/teams/9194/zh_TW/)\n"
+"Language-Team: Chinese (Taiwan) (https://app.transifex.com/pressbooks/teams/"
+"9194/zh_TW/)\n"
+"Language: zh_TW\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"Language: zh_TW\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Domain: pressbooks-aldine\n"
 "X-Generator: WP-CLI 2.11.0\n"
@@ -37,8 +39,8 @@ msgid ""
 "named for the Aldine Press, founded by Aldus Manutius in 1494, who is "
 "regarded by many as the world’s first publisher."
 msgstr ""
-"Aldine 是 Pressbooks 网络主页的默认主题。它以 Aldine 出版社命名，该出版社由 Aldus Manutius 于 1494 "
-"年创立，被许多人视为世界上第一位出版商。"
+"Aldine 是 Pressbooks 网络主页的默认主题。它以 Aldine 出版社命名，该出版社由 "
+"Aldus Manutius 于 1494 年创立，被许多人视为世界上第一位出版商。"
 
 #. Author of the theme
 #: style.css
@@ -215,7 +217,8 @@ msgstr "关于Pressbooks"
 msgid ""
 "Pressbooks is easy-to-use book writing software that lets you create a book "
 "in all the formats you need to publish."
-msgstr "Pressbooks 是一款易于使用的图书写作软件，可让您创建需要发布的所有格式的图书。"
+msgstr ""
+"Pressbooks 是一款易于使用的图书写作软件，可让您创建需要发布的所有格式的图书。"
 
 #: inc/activation/namespace.php:30
 msgid "Learn More"
@@ -233,8 +236,9 @@ msgid ""
 "educational resources, textbooks, scholarly monographs, fiction and non-"
 "fiction books, white papers, syllabi, and more."
 msgstr ""
-"Pressbooks 是一款简单的图书制作软件，可让您轻松编写、开发和分享您的想法。您可以使用 Pressbooks "
-"发布开放教育资源、教科书、学术专著、小说和非小说类书籍、白皮书、教学大纲等。"
+"Pressbooks 是一款简单的图书制作软件，可让您轻松编写、开发和分享您的想法。您可"
+"以使用 Pressbooks 发布开放教育资源、教科书、学术专著、小说和非小说类书籍、白"
+"皮书、教学大纲等。"
 
 #: inc/activation/namespace.php:43
 msgid ""
@@ -242,7 +246,8 @@ msgid ""
 "produce exports in multiple formats, including accessible EPUBs and PDFs "
 "specially designed for print-on-demand or digital distribution."
 msgstr ""
-"Pressbooks 让创作者能够快速将其内容发布到网络上并以多种格式导出，包括专为按需印刷或数字发行而设计的可访问 EPUB 和 PDF。"
+"Pressbooks 让创作者能够快速将其内容发布到网络上并以多种格式导出，包括专为按需"
+"印刷或数字发行而设计的可访问 EPUB 和 PDF。"
 
 #: inc/activation/namespace.php:47
 msgid "suite of products"
@@ -263,20 +268,23 @@ msgid ""
 "Are you looking for help on your Pressbooks project? The most comprehensive "
 "resource available is the %s, which contains everything you need to know "
 "about creating, enriching and exporting your work."
-msgstr "您是否在寻求有关 Pressbooks 项目的帮助？最全面的资源是%s ，其中包含有关创建、丰富和导出作品所需了解的一切。"
+msgstr ""
+"您是否在寻求有关 Pressbooks 项目的帮助？最全面的资源是%s ，其中包含有关创建、"
+"丰富和导出作品所需了解的一切。"
 
 #: inc/activation/namespace.php:62
 msgid "Pressbooks User Guide"
 msgstr "Pressbooks用户指南"
 
-#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to
-#. Fundamental of Pressbooks YouTube playlist
+#. translators: %1$s: link to Pressbooks YouTube channel; %2$s: link to Fundamental of Pressbooks YouTube playlist
 #: inc/activation/namespace.php:66
 msgid ""
 "You can find short video tutorials and webinars about features and product "
 "updates on the %1$s. If you’re just getting started with Pressbooks, this "
 "%2$s will guide you."
-msgstr "您可以在%1$s上找到有关功能和产品更新的简短视频教程和网络研讨会。如果您刚刚开始使用 Pressbooks，此%2$s将为您提供指导。"
+msgstr ""
+"您可以在%1$s上找到有关功能和产品更新的简短视频教程和网络研讨会。如果您刚刚开"
+"始使用 Pressbooks，此%2$s将为您提供指导。"
 
 #: inc/activation/namespace.php:67
 msgid "Pressbooks YouTube channel"
@@ -291,21 +299,23 @@ msgstr "短视频系列"
 msgid ""
 "If you learn best by learning by attending live training sessions, you can "
 "register for and attend one of Pressbooks' %s."
-msgstr "如果您通过参加现场培训课程获得最佳学习效果，您可以注册并参加 Pressbooks 的%s中一项课程。"
+msgstr ""
+"如果您通过参加现场培训课程获得最佳学习效果，您可以注册并参加 Pressbooks 的%s"
+"中一项课程。"
 
 #: inc/activation/namespace.php:73
 msgid "monthly webinars"
 msgstr "阅读研讨会"
 
-#. translators: %1$s: link to Pressbooks support page; %2$s: link to
-#. Pressbooks community forum
+#. translators: %1$s: link to Pressbooks support page; %2$s: link to Pressbooks community forum
 #: inc/activation/namespace.php:77
 msgid ""
 "The %1$s also contains links to other useful support resources and has "
 "answers to some commonly asked questions. Pressbooks also maintains a %2$s "
 "where you can ask and answer questions of other users."
 msgstr ""
-"%1$s还包含指向其他有用支持资源的链接，并回答一些常见问题。Pressbooks 还维护一个%2$s，您可以在其中提问和回答其他用户的问题。"
+"%1$s还包含指向其他有用支持资源的链接，并回答一些常见问题。Pressbooks 还维护一"
+"个%2$s，您可以在其中提问和回答其他用户的问题。"
 
 #: inc/activation/namespace.php:78
 msgid "Pressbooks support page"
@@ -321,7 +331,9 @@ msgid ""
 "For additional support needs, reach out to your institution’s Pressbooks "
 "network managers. If you don’t know who your network managers are, please "
 "fill out the %s to be put in touch with them."
-msgstr "如需更多支持，请联系您所在机构的 Pressbooks 网络管理员。如果您不知道您的网络管理员是谁，请填写表格%s以便与他们取得联系。"
+msgstr ""
+"如需更多支持，请联系您所在机构的 Pressbooks 网络管理员。如果您不知道您的网络"
+"管理员是谁，请填写表格%s以便与他们取得联系。"
 
 #: inc/activation/namespace.php:84
 msgid "support request form"
@@ -600,7 +612,8 @@ msgstr "未找到任何东西"
 
 #. translators: 1: link to WP admin new post page.
 #: partials/content-none.php:27
-msgid "Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
+msgid ""
+"Ready to publish your first post? <a href=\"%1$s\">Get started here</a>."
 msgstr "准备好发布了吗？ <a href=\"%1$s\">点此开始</a>。"
 
 #: partials/content-none.php:41


### PR DESCRIPTION
Translations update from [Pressbooks Weblate](https://translate.pressbooks.org) for [Pressbooks/Pressbooks Aldine](https://translate.pressbooks.org/projects/pressbooks/pressbooks-aldine/).



Current translation status:

![Weblate translation status](https://translate.pressbooks.org/widget/pressbooks/pressbooks-aldine/horizontal-auto.svg)