### PR TITLE
fix: new dist path

### DIFF
--- a/inc/actions/namespace.php
+++ b/inc/actions/namespace.php
@@ -68,7 +68,7 @@ function setup() {
 	// Set up the WordPress core custom header feature.
 	add_theme_support(
 		'custom-header', [
-			'default-image' => get_template_directory_uri() . '/dist/images/header.jpg',
+			'default-image' => get_template_directory_uri() . '/assets/dist/images/header.jpg',
 			'width' => 1920,
 			'height' => 884,
 			'default-text-color' => '#000',
@@ -78,8 +78,8 @@ function setup() {
 	// Register default header so WordPress knows how to update it back to it.
 	register_default_headers( [
 		'header' => [
-			'url' => get_template_directory_uri() . '/dist/images/header.jpg',
-			'thumbnail_url' => get_template_directory_uri() . '/dist/images/header.jpg',
+			'url' => get_template_directory_uri() . '/assets/dist/images/header.jpg',
+			'thumbnail_url' => get_template_directory_uri() . '/assets/dist/images/header.jpg',
 			'description' => __( 'Default Header', 'pressbooks-aldine' ),
 		],
 	] );

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -591,8 +591,8 @@ function get_header_tag(): string {
 	$background_url = match ( true ) {
 		has_post_thumbnail() => get_the_post_thumbnail_url(),
 		( is_front_page() || get_page_template_slug() === 'page-custom-home.php' ) && has_header_image() => get_header_image(),
-		get_page_template_slug() === 'page-custom-home.php' || is_front_page() => get_template_directory_uri() . '/dist/images/header.jpg',
-		default => get_template_directory_uri() . '/dist/images/catalog-header.jpg',
+		get_page_template_slug() === 'page-custom-home.php' || is_front_page() => get_template_directory_uri() . '/assets/dist/images/header.jpg',
+		default => get_template_directory_uri() . '/assets/dist/images/catalog-header.jpg',
 	};
 
 	return sprintf(

--- a/tests/test-helpers.php
+++ b/tests/test-helpers.php
@@ -19,7 +19,7 @@ class HelpersTest extends WP_UnitTestCase {
 		$result = get_header_tag();
 		
 		// Should return catalog header by default
-		$expected_url = get_template_directory_uri() . '/dist/images/catalog-header.jpg';
+		$expected_url = get_template_directory_uri() . '/assets/dist/images/catalog-header.jpg';
 		$this->assertStringContainsString( $expected_url, $result );
 		$this->assertStringContainsString( "class='header'", $result );
 		$this->assertStringContainsString( "role='banner'", $result );


### PR DESCRIPTION
Address #548 

This pull request updates image path references throughout the codebase to reflect a new directory structure, moving image assets from the `dist/images` folder to `assets/dist/images`. This ensures that both the theme setup and helper functions use the correct paths, and that tests are updated accordingly.

**Image Path Updates:**

* Updated the `default-image` path in the `add_theme_support('custom-header', ...)` call in `namespace.php` to use `assets/dist/images/header.jpg`.
* Updated the `url` and `thumbnail_url` in the `register_default_headers` call in `namespace.php` to use `assets/dist/images/header.jpg`.
* Updated the default image paths in the `get_header_tag` function in `namespace.php` to use `assets/dist/images/header.jpg` and `assets/dist/images/catalog-header.jpg`.

**Test Updates:**

* Updated the expected image path in `test_get_header_tag_default_catalog` in `test-helpers.php` to use `assets/dist/images/catalog-header.jpg`.