### PR TITLE
fix: pressbooks assets

### DIFF
--- a/inc/filters/namespace.php
+++ b/inc/filters/namespace.php
@@ -8,8 +8,8 @@
 namespace Aldine\Filters;
 
 use function Aldine\Helpers\has_sections;
-use PressbooksFrontendTools\AssetType;
 use PressbooksFrontendTools\Assets;
+use PressbooksFrontendTools\AssetType;
 
 /**
  * Adds custom classes to the array of body classes.

--- a/inc/filters/namespace.php
+++ b/inc/filters/namespace.php
@@ -88,8 +88,8 @@ function adjust_menu( $items, $args ) {
 function add_buttons( $plugin_array ) {
 	$assets = new Assets( 'pressbooks-aldine', AssetType::THEME );
 
-	$plugin_array['aldine_call_to_action'] = $assets->getPath( 'scripts/call-to-action.js' );
-	$plugin_array['aldine_page_section'] = $assets->getPath( 'scripts/page-section.js' );
+	$plugin_array['aldine_call_to_action'] = $assets->getAssetUrl( 'assets/scripts/call-to-action.js' );
+	$plugin_array['aldine_page_section'] = $assets->getAssetUrl( 'assets/scripts/page-section.js' );
 	return $plugin_array;
 }
 

--- a/inc/filters/namespace.php
+++ b/inc/filters/namespace.php
@@ -8,7 +8,8 @@
 namespace Aldine\Filters;
 
 use function Aldine\Helpers\has_sections;
-use PressbooksMix\Assets;
+use PressbooksFrontendTools\AssetType;
+use PressbooksFrontendTools\Assets;
 
 /**
  * Adds custom classes to the array of body classes.
@@ -85,8 +86,7 @@ function adjust_menu( $items, $args ) {
  * @since 1.1.0
  */
 function add_buttons( $plugin_array ) {
-	$assets = new Assets( 'pressbooks-aldine', 'theme' );
-	$assets->setSrcDirectory( 'assets' )->setDistDirectory( 'dist' );
+	$assets = new Assets( 'pressbooks-aldine', AssetType::THEME );
 
 	$plugin_array['aldine_call_to_action'] = $assets->getPath( 'scripts/call-to-action.js' );
 	$plugin_array['aldine_page_section'] = $assets->getPath( 'scripts/page-section.js' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -13074,31 +13074,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/pressbooks-build-tools/node_modules/sugarss": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/sugarss/-/sugarss-5.0.1.tgz",
-			"integrity": "sha512-ctS5RYCBVvPoZAnzIaX5QSShK8ZiZxD5HUqSxlusvEMC+QZQIPCPOIJg6aceFX+K2rf4+SH89eu++h1Zmsr2nw==",
-			"dev": true,
-			"funding": [
-				{
-					"type": "opencollective",
-					"url": "https://opencollective.com/postcss/"
-				},
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/ai"
-				}
-			],
-			"license": "MIT",
-			"optional": true,
-			"peer": true,
-			"engines": {
-				"node": ">=18.0"
-			},
-			"peerDependencies": {
-				"postcss": "^8.3.3"
-			}
-		},
 		"node_modules/pressbooks-build-tools/node_modules/vite": {
 			"version": "7.3.1",
 			"resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
@@ -19558,24 +19533,6 @@
 			"integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/yaml": {
-			"version": "2.8.2",
-			"resolved": "https://registry.npmjs.org/yaml/-/yaml-2.8.2.tgz",
-			"integrity": "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A==",
-			"dev": true,
-			"license": "ISC",
-			"optional": true,
-			"peer": true,
-			"bin": {
-				"yaml": "bin.mjs"
-			},
-			"engines": {
-				"node": ">= 14.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/eemeli"
-			}
 		},
 		"node_modules/yargs": {
 			"version": "17.7.2",


### PR DESCRIPTION
This pull request updates how frontend assets are handled in the `inc/filters/namespace.php` file to use the newer `PressbooksFrontendTools` asset management system. The changes modernize asset loading and improve code clarity.

**Asset management improvements:**

* Switched from using `PressbooksMix\Assets` to `PressbooksFrontendTools\Assets` and `AssetType`, updating the import statements accordingly.
* Refactored the `add_buttons` function to instantiate `Assets` with the new `AssetType::THEME` instead of a string, and replaced `getPath` with `getAssetUrl` for retrieving JavaScript asset URLs. This also removes the need to manually set source and distribution directories.