### PR TITLE
feat: add contact form hooks for custom validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,13 @@
 
 Contributors: conner_bw, greatislander, steelwagstaff
 Tags: publishing, catalog, pressbooks, default-theme
-Requires at least: 6.4.3 
+Requires at least: 6.4.3
 Tested up to: 6.9.1
 <!-- x-release-please-start-version -->
 Stable tag: 1.19.1
 <!-- x-release-please-end -->
 Requires PHP: 8.3
-License: GNU General Public License v3 or later 
+License: GNU General Public License v3 or later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
 Aldine is the default theme for the home page of Pressbooks networks. It is named for the Aldine Press, founded by Aldus Manutius in 1494, who is regarded by many as the world’s first publisher.
@@ -30,6 +30,11 @@ Aldine is the default theme for the home page of [Pressbooks](https://pressbooks
 1. In your admin panel, go to Appearance > Themes and click the Add New button.
 2. Click Upload Theme and Choose File, then select the theme's [.zip file](https://github.com/pressbooks/pressbooks-aldine/releases/latest/). Click Install Now.
 3. Click Activate to use your new theme right away.
+
+## Hooks
+
+- `do_action( 'pressbooks_aldine_contact_form_before_submit' )` — Fires before the submit button in the contact form.
+- `apply_filters( 'pressbooks_aldine_contact_form_submission_valid', true, $_POST )` — Filters whether the contact form submission passes server-side validation.
 
 ### Changelog
 Please see the [CHANGELOG](CHANGELOG.md) file for more information.

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -443,40 +443,6 @@ function default_menu( $args = [], $items = '' ) {
 }
 
 /**
- * Render the Cloudflare Turnstile widget and enqueue its script.
- */
-function render_turnstile() {
-	if ( ! defined( 'CLOUDFLARE_TURNSTILE_SITE_KEY' ) ) {
-		return;
-	}
-	echo '<div class="cf-turnstile" data-sitekey="' . esc_attr( CLOUDFLARE_TURNSTILE_SITE_KEY ) . '"></div>';
-	wp_enqueue_script( 'cf-turnstile', 'https://challenges.cloudflare.com/turnstile/v0/api.js', [], null, true );
-}
-
-/**
- * Verify a Cloudflare Turnstile token.
- *
- * @return bool
- */
-function verify_turnstile(): bool {
-	if ( ! defined( 'CLOUDFLARE_TURNSTILE_SECRET_KEY' ) ) {
-		return true;
-	}
-
-	// Nonce verification is handled by the form/action that calls this helper.
-	// phpcs:ignore Pressbooks.Security.NonceVerification.Missing
-	$token = $_POST['cf-turnstile-response'] ?? '';
-	$verify = wp_remote_post( 'https://challenges.cloudflare.com/turnstile/v0/siteverify', [
-		'body' => [
-			'secret' => CLOUDFLARE_TURNSTILE_SECRET_KEY,
-			'response' => $token,
-		],
-	] );
-	$result = json_decode( wp_remote_retrieve_body( $verify ), true );
-	return ! empty( $result['success'] );
-}
-
-/**
  *
  * Handler for contact form submissions.
  *
@@ -493,10 +459,21 @@ function handle_contact_form_submission() {
 				return false; // Honeypot failed.
 			}
 		}
-		if ( ! verify_turnstile() ) {
+		/**
+		 * Filters whether the contact form submission is valid.
+		 *
+		 * Plugins may use this filter to perform additional server-side
+		 * validation (e.g. CAPTCHA verification) before the contact form
+		 * email is sent. Return false to block the submission.
+		 *
+		 * @since 1.0.0
+		 * @param bool $valid Whether the submission is valid.
+		 * @param array $post_data The raw $_POST data.
+		 */
+		if ( ! apply_filters( 'pressbooks_aldine_contact_form_submission_valid', true, $_POST ) ) {
 			$output['message'] = __( 'Verification failed. Please try again.', 'pressbooks-aldine' );
 			$output['status'] = 'error';
-			$output['field'] = 'cf-turnstile-response';
+			$output['field'] = 'contact_form_validation';
 			return $output;
 		}
 		$contact_email = get_option( 'pb_network_contact_email', get_option( 'admin_email' ) );

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -459,17 +459,6 @@ function handle_contact_form_submission() {
 				return false; // Honeypot failed.
 			}
 		}
-		/**
-		 * Filters whether the contact form submission is valid.
-		 *
-		 * Plugins may use this filter to perform additional server-side
-		 * validation (e.g. CAPTCHA verification) before the contact form
-		 * email is sent. Return false to block the submission.
-		 *
-		 * @since 1.0.0
-		 * @param bool $valid Whether the submission is valid.
-		 * @param array $post_data The raw $_POST data.
-		 */
 		if ( ! apply_filters( 'pressbooks_aldine_contact_form_submission_valid', true, $_POST ) ) {
 			$output['message'] = __( 'Verification failed. Please try again.', 'pressbooks-aldine' );
 			$output['status'] = 'error';

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -462,6 +462,9 @@ function verify_turnstile(): bool {
 	if ( ! defined( 'CLOUDFLARE_TURNSTILE_SECRET_KEY' ) ) {
 		return true;
 	}
+
+	// Nonce verification is handled by the form/action that calls this helper.
+	// phpcs:ignore Pressbooks.Security.NonceVerification.Missing
 	$token = $_POST['cf-turnstile-response'] ?? '';
 	$verify = wp_remote_post( 'https://challenges.cloudflare.com/turnstile/v0/siteverify', [
 		'body' => [

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -443,6 +443,37 @@ function default_menu( $args = [], $items = '' ) {
 }
 
 /**
+ * Render the Cloudflare Turnstile widget and enqueue its script.
+ */
+function render_turnstile() {
+	if ( ! defined( 'CLOUDFLARE_TURNSTILE_SITE_KEY' ) ) {
+		return;
+	}
+	echo '<div class="cf-turnstile" data-sitekey="' . esc_attr( CLOUDFLARE_TURNSTILE_SITE_KEY ) . '"></div>';
+	wp_enqueue_script( 'cf-turnstile', 'https://challenges.cloudflare.com/turnstile/v0/api.js', [], null, true );
+}
+
+/**
+ * Verify a Cloudflare Turnstile token.
+ *
+ * @return bool
+ */
+function verify_turnstile(): bool {
+	if ( ! defined( 'CLOUDFLARE_TURNSTILE_SECRET_KEY' ) ) {
+		return true;
+	}
+	$token = $_POST['cf-turnstile-response'] ?? '';
+	$verify = wp_remote_post( 'https://challenges.cloudflare.com/turnstile/v0/siteverify', [
+		'body' => [
+			'secret' => CLOUDFLARE_TURNSTILE_SECRET_KEY,
+			'response' => $token,
+		],
+	] );
+	$result = json_decode( wp_remote_retrieve_body( $verify ), true );
+	return ! empty( $result['success'] );
+}
+
+/**
  *
  * Handler for contact form submissions.
  *
@@ -459,21 +490,11 @@ function handle_contact_form_submission() {
 				return false; // Honeypot failed.
 			}
 		}
-		if ( defined( 'CLOUDFLARE_TURNSTILE_SECRET_KEY' ) ) {
-			$token = $_POST['cf-turnstile-response'] ?? '';
-			$verify = wp_remote_post( 'https://challenges.cloudflare.com/turnstile/v0/siteverify', [
-				'body' => [
-					'secret' => CLOUDFLARE_TURNSTILE_SECRET_KEY,
-					'response' => $token,
-				],
-			] );
-			$result = json_decode( wp_remote_retrieve_body( $verify ), true );
-			if ( empty( $result['success'] ) ) {
-				$output['message'] = __( 'Verification failed. Please try again.', 'pressbooks-aldine' );
-				$output['status'] = 'error';
-				$output['field'] = 'cf-turnstile-response';
-				return $output;
-			}
+		if ( ! verify_turnstile() ) {
+			$output['message'] = __( 'Verification failed. Please try again.', 'pressbooks-aldine' );
+			$output['status'] = 'error';
+			$output['field'] = 'cf-turnstile-response';
+			return $output;
 		}
 		$contact_email = get_option( 'pb_network_contact_email', get_option( 'admin_email' ) );
 		$output = [];

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -459,6 +459,22 @@ function handle_contact_form_submission() {
 				return false; // Honeypot failed.
 			}
 		}
+		if ( defined( 'CLOUDFLARE_TURNSTILE_SECRET_KEY' ) ) {
+			$token = $_POST['cf-turnstile-response'] ?? '';
+			$verify = wp_remote_post( 'https://challenges.cloudflare.com/turnstile/v0/siteverify', [
+				'body' => [
+					'secret' => CLOUDFLARE_TURNSTILE_SECRET_KEY,
+					'response' => $token,
+				],
+			] );
+			$result = json_decode( wp_remote_retrieve_body( $verify ), true );
+			if ( empty( $result['success'] ) ) {
+				$output['message'] = __( 'Verification failed. Please try again.', 'pressbooks-aldine' );
+				$output['status'] = 'error';
+				$output['field'] = 'cf-turnstile-response';
+				return $output;
+			}
+		}
 		$contact_email = get_option( 'pb_network_contact_email', get_option( 'admin_email' ) );
 		$output = [];
 		$name = ( isset( $_POST['visitor_name'] ) ) ? $_POST['visitor_name'] : '';

--- a/partials/contact-form.php
+++ b/partials/contact-form.php
@@ -99,10 +99,7 @@ $honeypot = 'firstname' . wp_rand();
 				<?php _e( 'Your message (required)', 'pressbooks-aldine' ); ?>
 			</label>
 		</p>
-		<?php if ( defined( 'CLOUDFLARE_TURNSTILE_SITE_KEY' ) ) : ?>
-		<div class="cf-turnstile" data-sitekey="<?php echo CLOUDFLARE_TURNSTILE_SITE_KEY; ?>"></div>
-		<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
-		<?php endif; ?>
+		<?php \Aldine\Helpers\render_turnstile(); ?>
 		<p class="form__row">
 			<input class="button button--small button--outline" type="submit" value="<?php _e( 'Send', 'pressbooks-aldine' ); ?>" /></p>
 	</form>

--- a/partials/contact-form.php
+++ b/partials/contact-form.php
@@ -99,7 +99,17 @@ $honeypot = 'firstname' . wp_rand();
 				<?php _e( 'Your message (required)', 'pressbooks-aldine' ); ?>
 			</label>
 		</p>
-		<?php \Aldine\Helpers\render_turnstile(); ?>
+		<?php
+		/**
+		 * Fires before the submit button in the contact form.
+		 *
+		 * Plugins may use this action to render additional fields or
+		 * widgets (e.g. a CAPTCHA) before the submit button.
+		 *
+		 * @since 1.0.0
+		 */
+		do_action( 'pressbooks_aldine_contact_form_before_submit' );
+		?>
 		<p class="form__row">
 			<input class="button button--small button--outline" type="submit" value="<?php _e( 'Send', 'pressbooks-aldine' ); ?>" /></p>
 	</form>

--- a/partials/contact-form.php
+++ b/partials/contact-form.php
@@ -99,17 +99,7 @@ $honeypot = 'firstname' . wp_rand();
 				<?php _e( 'Your message (required)', 'pressbooks-aldine' ); ?>
 			</label>
 		</p>
-		<?php
-		/**
-		 * Fires before the submit button in the contact form.
-		 *
-		 * Plugins may use this action to render additional fields or
-		 * widgets (e.g. a CAPTCHA) before the submit button.
-		 *
-		 * @since 1.0.0
-		 */
-		do_action( 'pressbooks_aldine_contact_form_before_submit' );
-		?>
+		<?php do_action( 'pressbooks_aldine_contact_form_before_submit' ); ?>
 		<p class="form__row">
 			<input class="button button--small button--outline" type="submit" value="<?php _e( 'Send', 'pressbooks-aldine' ); ?>" /></p>
 	</form>

--- a/partials/contact-form.php
+++ b/partials/contact-form.php
@@ -99,6 +99,10 @@ $honeypot = 'firstname' . wp_rand();
 				<?php _e( 'Your message (required)', 'pressbooks-aldine' ); ?>
 			</label>
 		</p>
+		<?php if ( defined( 'CLOUDFLARE_TURNSTILE_SITE_KEY' ) ) : ?>
+		<div class="cf-turnstile" data-sitekey="<?php echo CLOUDFLARE_TURNSTILE_SITE_KEY; ?>"></div>
+		<script src="https://challenges.cloudflare.com/turnstile/v0/api.js" async defer></script>
+		<?php endif; ?>
 		<p class="form__row">
 			<input class="button button--small button--outline" type="submit" value="<?php _e( 'Send', 'pressbooks-aldine' ); ?>" /></p>
 	</form>

--- a/tests/test-contact-form.php
+++ b/tests/test-contact-form.php
@@ -2,7 +2,7 @@
 
 use function Aldine\Helpers\handle_contact_form_submission;
 
-class TurnstileTest extends WP_UnitTestCase {
+class ContactFormTest extends WP_UnitTestCase {
 
 	public function test_validation_filter_can_block_submission() {
 		$wp_mail_called = false;

--- a/tests/test-turnstile.php
+++ b/tests/test-turnstile.php
@@ -1,0 +1,63 @@
+<?php
+
+use function Aldine\Helpers\render_turnstile;
+use function Aldine\Helpers\verify_turnstile;
+use function Aldine\Helpers\handle_contact_form_submission;
+
+class TurnstileTest extends WP_UnitTestCase {
+
+	public function test_render_turnstile_no_constant() {
+		$this->assertNull( render_turnstile() );
+		$this->expectOutputString( '' );
+		render_turnstile();
+	}
+
+	public function test_render_turnstile_with_constant() {
+		define( 'CLOUDFLARE_TURNSTILE_SITE_KEY', '0x4AAAAAAA' );
+		$this->expectOutputRegex( '/data-sitekey="0x4AAAAAAA"/' );
+		render_turnstile();
+		$this->assertTrue( wp_script_is( 'cf-turnstile', 'enqueued' ) );
+	}
+
+	public function test_verify_turnstile_no_constant() {
+		$this->assertTrue( verify_turnstile() );
+	}
+
+	public function test_verify_turnstile_missing_token() {
+		define( 'CLOUDFLARE_TURNSTILE_SECRET_KEY', '0x4AAAAAAA' );
+		unset( $_POST['cf-turnstile-response'] );
+		$this->assertFalse( verify_turnstile() );
+	}
+
+	public function test_verify_turnstile_success() {
+		define( 'CLOUDFLARE_TURNSTILE_SECRET_KEY', '0x4AAAAAAA' );
+		$_POST['cf-turnstile-response'] = 'valid-token';
+		add_filter( 'pre_http_request', function () {
+			return [ 'body' => wp_json_encode( [ 'success' => true ] ) ];
+		} );
+		$this->assertTrue( verify_turnstile() );
+	}
+
+	public function test_verify_turnstile_failure() {
+		define( 'CLOUDFLARE_TURNSTILE_SECRET_KEY', '0x4AAAAAAA' );
+		$_POST['cf-turnstile-response'] = 'bad-token';
+		add_filter( 'pre_http_request', function () {
+			return [ 'body' => wp_json_encode( [ 'success' => false ] ) ];
+		} );
+		$this->assertFalse( verify_turnstile() );
+	}
+
+	public function test_contact_form_rejects_failed_turnstile() {
+		define( 'CLOUDFLARE_TURNSTILE_SECRET_KEY', '0x4AAAAAAA' );
+		$_POST['pb_root_contact_form_nonce'] = wp_create_nonce( 'pb_root_contact_form' );
+		$_POST['submitted'] = '1';
+		$_POST['cf-turnstile-response'] = 'bad-token';
+		add_filter( 'pre_http_request', function () {
+			return [ 'body' => wp_json_encode( [ 'success' => false ] ) ];
+		} );
+		$result = handle_contact_form_submission();
+		$this->assertIsArray( $result );
+		$this->assertEquals( 'error', $result['status'] );
+		$this->assertEquals( 'cf-turnstile-response', $result['field'] );
+	}
+}

--- a/tests/test-turnstile.php
+++ b/tests/test-turnstile.php
@@ -1,63 +1,58 @@
 <?php
 
-use function Aldine\Helpers\render_turnstile;
-use function Aldine\Helpers\verify_turnstile;
 use function Aldine\Helpers\handle_contact_form_submission;
 
 class TurnstileTest extends WP_UnitTestCase {
 
-	public function test_render_turnstile_no_constant() {
-		$this->assertNull( render_turnstile() );
-		$this->expectOutputString( '' );
-		render_turnstile();
-	}
-
-	public function test_render_turnstile_with_constant() {
-		define( 'CLOUDFLARE_TURNSTILE_SITE_KEY', '0x4AAAAAAA' );
-		$this->expectOutputRegex( '/data-sitekey="0x4AAAAAAA"/' );
-		render_turnstile();
-		$this->assertTrue( wp_script_is( 'cf-turnstile', 'enqueued' ) );
-	}
-
-	public function test_verify_turnstile_no_constant() {
-		$this->assertTrue( verify_turnstile() );
-	}
-
-	public function test_verify_turnstile_missing_token() {
-		define( 'CLOUDFLARE_TURNSTILE_SECRET_KEY', '0x4AAAAAAA' );
-		unset( $_POST['cf-turnstile-response'] );
-		$this->assertFalse( verify_turnstile() );
-	}
-
-	public function test_verify_turnstile_success() {
-		define( 'CLOUDFLARE_TURNSTILE_SECRET_KEY', '0x4AAAAAAA' );
-		$_POST['cf-turnstile-response'] = 'valid-token';
-		add_filter( 'pre_http_request', function () {
-			return [ 'body' => wp_json_encode( [ 'success' => true ] ) ];
+	public function test_validation_filter_can_block_submission() {
+		$wp_mail_called = false;
+		add_filter( 'pre_wp_mail', function () use ( &$wp_mail_called ) {
+			$wp_mail_called = true;
+			return false;
 		} );
-		$this->assertTrue( verify_turnstile() );
-	}
 
-	public function test_verify_turnstile_failure() {
-		define( 'CLOUDFLARE_TURNSTILE_SECRET_KEY', '0x4AAAAAAA' );
-		$_POST['cf-turnstile-response'] = 'bad-token';
-		add_filter( 'pre_http_request', function () {
-			return [ 'body' => wp_json_encode( [ 'success' => false ] ) ];
-		} );
-		$this->assertFalse( verify_turnstile() );
-	}
+		add_filter( 'pressbooks_aldine_contact_form_submission_valid', '__return_false' );
 
-	public function test_contact_form_rejects_failed_turnstile() {
-		define( 'CLOUDFLARE_TURNSTILE_SECRET_KEY', '0x4AAAAAAA' );
 		$_POST['pb_root_contact_form_nonce'] = wp_create_nonce( 'pb_root_contact_form' );
 		$_POST['submitted'] = '1';
-		$_POST['cf-turnstile-response'] = 'bad-token';
-		add_filter( 'pre_http_request', function () {
-			return [ 'body' => wp_json_encode( [ 'success' => false ] ) ];
-		} );
+		$_POST['visitor_name'] = 'John Doe';
+		$_POST['visitor_email'] = 'john@example.com';
+		$_POST['visitor_institution'] = 'Test University';
+		$_POST['message'] = 'Test message';
+
 		$result = handle_contact_form_submission();
+
 		$this->assertIsArray( $result );
 		$this->assertEquals( 'error', $result['status'] );
-		$this->assertEquals( 'cf-turnstile-response', $result['field'] );
+		$this->assertFalse( $wp_mail_called, 'wp_mail should not be called when validation filter blocks submission' );
+	}
+
+	public function test_contact_form_succeeds_without_plugin_block() {
+		add_filter( 'pre_wp_mail', '__return_true' );
+
+		$_POST['pb_root_contact_form_nonce'] = wp_create_nonce( 'pb_root_contact_form' );
+		$_POST['submitted'] = '1';
+		$_POST['visitor_name'] = 'Jane Doe';
+		$_POST['visitor_email'] = 'jane@example.com';
+		$_POST['visitor_institution'] = 'Test College';
+		$_POST['message'] = 'Hello, this is a test.';
+
+		$result = handle_contact_form_submission();
+
+		$this->assertIsArray( $result );
+		$this->assertEquals( 'success', $result['status'] );
+	}
+
+	public function test_before_submit_action_outputs_content() {
+		add_action( 'pressbooks_aldine_contact_form_before_submit', function () {
+			echo '<div class="my-captcha">My CAPTCHA</div>';
+		} );
+
+		ob_start();
+		do_action( 'pressbooks_aldine_contact_form_before_submit' );
+		$output = ob_get_clean();
+
+		$this->assertStringContainsString( 'my-captcha', $output );
+		$this->assertStringContainsString( 'My CAPTCHA', $output );
 	}
 }


### PR DESCRIPTION
This adds two new hooks to the contact form so plugins can hook in security features (like CAPTCHA) without the theme needing to know about them.

**What's new**

Plugins can now inject content before the submit button:

```php
do_action( 'pressbooks_aldine_contact_form_before_submit' )
apply_filters( 'pressbooks_aldine_contact_form_submission_valid', true, $_POST )
```

Plugins can now validate submissions server-side before the email goes out:

Also included
- Tests that prove both hooks work
- README documentation