### PR TITLE
feat: WP 7.x support

### DIFF
--- a/inc/activation/namespace.php
+++ b/inc/activation/namespace.php
@@ -7,6 +7,7 @@
 
 namespace Aldine\Activation;
 
+use function Aldine\Helpers\find_page_by_title;
 use function Aldine\Helpers\get_catalog_page;
 
 /**
@@ -167,7 +168,7 @@ function create_menus() {
 	if ( ! wp_get_nav_menu_object( $menu_name ) ) {
 		$menu_id = wp_create_nav_menu( $menu_name );
 
-		$about = get_page_by_title( __( 'About', 'pressbooks-aldine' ) );
+		$about = find_page_by_title( __( 'About', 'pressbooks-aldine' ) );
 		if ( $about ) {
 			wp_update_nav_menu_item(
 				$menu_id,
@@ -197,7 +198,7 @@ function create_menus() {
 			);
 		}
 
-		$help = get_page_by_title( __( 'Help', 'pressbooks-aldine' ) );
+		$help = find_page_by_title( __( 'Help', 'pressbooks-aldine' ) );
 		if ( $help ) {
 			wp_update_nav_menu_item(
 				$menu_id,

--- a/inc/helpers/namespace.php
+++ b/inc/helpers/namespace.php
@@ -573,6 +573,26 @@ function get_catalog_page(): ?\WP_Post {
 }
 
 /**
+ * Get a page by its exact title.
+ *
+ * Replacement for the WordPress get_page_by_title() function, deprecated in 6.2.0.
+ *
+ * @param string $title The page title to look up.
+ * @return WP_Post|null The matching page, or null if none is found.
+ */
+function find_page_by_title( string $title ): ?\WP_Post {
+	$pages = get_posts( [
+		'post_type' => 'page',
+		'title' => $title,
+		'post_status' => 'any',
+		'posts_per_page' => 1,
+		'orderby' => 'ID',
+		'order' => 'ASC',
+	] );
+	return $pages[0] ?? null;
+}
+
+/**
  * This function generate a class to know if the current page is a custom frontpage.
  *
  * @return string

--- a/tests/test-helpers.php
+++ b/tests/test-helpers.php
@@ -6,11 +6,40 @@
  */
 
 use function \Aldine\Helpers\get_header_tag;
+use function \Aldine\Helpers\find_page_by_title;
 
 /**
  * Helpers test case.
  */
 class HelpersTest extends WP_UnitTestCase {
+
+	/**
+	 * find_page_by_title() locates a published page by its exact title,
+	 * replacing WordPress' get_page_by_title() (deprecated in 6.2.0).
+	 *
+	 * @group wp7
+	 */
+	public function test_find_page_by_title_returns_matching_page() {
+		$page_id = $this->factory()->post->create( [
+			'post_type'   => 'page',
+			'post_title'  => 'About',
+			'post_status' => 'publish',
+		] );
+
+		$result = find_page_by_title( 'About' );
+
+		$this->assertInstanceOf( \WP_Post::class, $result );
+		$this->assertSame( $page_id, $result->ID );
+	}
+
+	/**
+	 * find_page_by_title() returns null when no page matches the title.
+	 *
+	 * @group wp7
+	 */
+	public function test_find_page_by_title_returns_null_when_no_match() {
+		$this->assertNull( find_page_by_title( 'Nonexistent Page Title 12345' ) );
+	}
 
 	/**
 	 * Test get_header_tag with no special conditions (catalog header).


### PR DESCRIPTION
Issue pressbooks/pressbooks#4523

Part of the WordPress 7.0 compatibility program.

### Summary
Replaces `get_page_by_title()` — deprecated in WordPress **6.2.0** (recommended
replacement: `WP_Query`) — with a small local helper.

### Why
The WP 7.0 audit of this theme found no regressions, but the deprecation sniff flagged
this pre-existing deprecated-API usage in the theme-activation menu builder.

### Changes
- `inc/helpers/namespace.php` — new `find_page_by_title( string $title ): ?WP_Post`,
  a `get_posts()` exact-title lookup mirroring the neighbouring `get_catalog_page()`.
- `inc/activation/namespace.php` — the "About" and "Help" footer-menu lookups now use
  the helper.

### Testing
- Added test-first (red → green): `test_find_page_by_title_returns_matching_page` and
  `test_find_page_by_title_returns_null_when_no_match`.
- The `WordPress.WP.DeprecatedFunctions` sniff for this theme goes from 1 finding → 0.
- Full suite green (22 tests, 48 assertions); `composer standards` clean.