### PR TITLE
fix: escape editor button i18n strings to prevent TinyMCE plugin init failures

### DIFF
--- a/inc/actions/namespace.php
+++ b/inc/actions/namespace.php
@@ -304,17 +304,17 @@ function tinymce_l18n() {
 	<script type='text/javascript'>
 		const aldine = {
 			page_section: {
-				'title': '<?php _e( 'Page Section', 'pressbooks-aldine' ); ?>',
-				'title_label': '<?php _e( 'Title', 'pressbooks-aldine' ); ?>',
-				'standard': '<?php _e( 'Standard', 'pressbooks-aldine' ); ?>',
-				'accent': '<?php _e( 'Accent', 'pressbooks-aldine' ); ?>',
-				'bordered': '<?php _e( 'Bordered', 'pressbooks-aldine' ); ?>',
-				'borderless': '<?php _e( 'Borderless', 'pressbooks-aldine' ); ?>'
+				'title': '<?php echo esc_js( __( 'Page Section', 'pressbooks-aldine' ) ); ?>',
+				'title_label': '<?php echo esc_js( __( 'Title', 'pressbooks-aldine' ) ); ?>',
+				'standard': '<?php echo esc_js( __( 'Standard', 'pressbooks-aldine' ) ); ?>',
+				'accent': '<?php echo esc_js( __( 'Accent', 'pressbooks-aldine' ) ); ?>',
+				'bordered': '<?php echo esc_js( __( 'Bordered', 'pressbooks-aldine' ) ); ?>',
+				'borderless': '<?php echo esc_js( __( 'Borderless', 'pressbooks-aldine' ) ); ?>'
 			},
 			call_to_action: {
-				'title': '<?php _e( 'Call to Action', 'pressbooks-aldine' ); ?>',
-				'text': '<?php _e( 'Text', 'pressbooks-aldine' ); ?>',
-				'link': '<?php _e( 'Link', 'pressbooks-aldine' ); ?>'
+				'title': '<?php echo esc_js( __( 'Call to Action', 'pressbooks-aldine' ) ); ?>',
+				'text': '<?php echo esc_js( __( 'Text', 'pressbooks-aldine' ) ); ?>',
+				'link': '<?php echo esc_js( __( 'Link', 'pressbooks-aldine' ) ); ?>'
 			}
 		};
 	</script>


### PR DESCRIPTION
## TLDR

Non-English users (e.g. French) editing pages on an Aldine root site see red errors in the classic editor:

> Failed to initialize plugin: aldine_call_to_action
> Failed to initialize plugin: aldine_page_section

This escapes the editor button i18n strings so translations containing apostrophes no longer break the inline script.

## Root cause

`Aldine\Actions\tinymce_l18n()` prints the `aldine` JS object by echoing translated strings straight into an inline `<script>` with `_e()` — no JS escaping:

```php
'title': '<?php _e( 'Call to Action', 'pressbooks-aldine' ); ?>',
```

For French, `Call to Action` translates to `Appel à l'action` (see `languages/fr_FR.po`, `fr_CA.po`). The unescaped apostrophe closes the JS string early:

```js
'title': 'Appel à l'action',   // SyntaxError
```

So `const aldine = { … }` never executes and `aldine` is left undefined. When TinyMCE then initializes the two external plugins (`inc/filters/namespace.php`), their `init()` reads `aldine.call_to_action.title` / `aldine.page_section.title`, throws, and TinyMCE reports both "Failed to initialize plugin" errors.

English sites are unaffected because those strings contain no quotes — which is why it never reproduced internally, only for open-source users on localized sites.

## What changed

- Wrapped each string in `tinymce_l18n()` with `esc_js( __() )` so apostrophes, quotes, and unicode are safely encoded. Output is byte-identical for English; French now emits `'Appel à l\'action'`.

## How to test

1. Set site language to **Français** (`fr_FR` or `fr_CA`).
2. As an editor/admin on an Aldine root site, open **Pages → Edit** (classic editor).
3. Before: two red "Failed to initialize plugin" banners; the Page Section / Call to Action toolbar buttons are missing.
4. After this change: no errors, and both toolbar buttons work.