### PR TITLE
fix: update minimum required versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
 
 Contributors: conner_bw, greatislander, steelwagstaff
 Tags: publishing, catalog, pressbooks, default-theme
-Requires at least: 6.4.3
-Tested up to: 6.9.1
+Requires at least: 7.0.4
+Tested up to: 7.0.4
 <!-- x-release-please-start-version -->
 Stable tag: 1.19.1
 <!-- x-release-please-end -->

--- a/phpcs.ruleset.xml
+++ b/phpcs.ruleset.xml
@@ -16,5 +16,5 @@
     </rule>
 	<!-- Run against the PHPCompatibility ruleset -->
 	<rule ref="PHPCompatibility"/>
-	<config name="testVersion" value="8.1-8.2"/>
+	<config name="testVersion" value="8.3-8.4"/>
 </ruleset>

--- a/style.css
+++ b/style.css
@@ -8,9 +8,9 @@ Tags:				publishing, catalog, pressbooks, default-theme
 x-release-please-start-version
 Version:			1.27.0
 x-release-please-end
-Requires at least:	6.4.3
-Tested up to:		6.6.2
-Requires PHP:		8.1
+Requires at least:	7.0.4
+Tested up to:		7.0.4
+Requires PHP:		8.3
 License:			GNU GPL v3 or later
 License URI:		https://github.com/pressbooks/pressbooks-aldine/tree/production/LICENSE.md
 Text Domain:		pressbooks-aldine


### PR DESCRIPTION
Bump the declared minimum WordPress version to 7.0.3 and align PHP requirements to 8.3 across all version declarations.

- style.css: Requires at least 6.4.3 -> 7.0.3, Tested up to 6.6.2 -> 7.0.3, Requires PHP 8.1 -> 8.3
- README.md: Requires at least 6.4.3 -> 7.0.3, Tested up to 6.9.1 -> 7.0.3
- phpcs.ruleset.xml: testVersion 8.1-8.2 -> 8.3-8.4